### PR TITLE
feat(heartbeat): default agent auto-enable + channel delivery

### DIFF
--- a/.dev/ACTIVE_PHASES.md
+++ b/.dev/ACTIVE_PHASES.md
@@ -4,12 +4,13 @@ This is the agent's entry point. Read this first on every invocation.
 
 ## Currently Active
 
-_(No active phases.)_
+| Phase | Status | Todo File | Requirement File | Tasks | Done |
+|-------|--------|-----------|------------------|-------|------|
+| 3 | NOT STARTED | todo/active/phase-03-heartbeat-default-enabled.md | _(bug fix, no separate spec)_ | 6 | 0 |
 
 ## Completed (do not read)
 
 | Phase | Todo File | Tasks | Done |
 |-------|-----------|-------|------|
 | 1 | todo/archive/phase-01-gemini-temp-chat.md | 4 | 4 |
-
-ALL PHASES COMPLETE
+| 2 | todo/archive/phase-02-heartbeat.md | 27 | 27 |

--- a/.dev/README.md
+++ b/.dev/README.md
@@ -148,7 +148,7 @@ PARALLEL=1 .dev/run_pipeline.sh
 |----------|---------|-------------|
 | `MAX_CYCLES` | 3 | Max code→review→fix cycles |
 | `AGENT_MAX_ITERATIONS` | 10 | Cap iterations per coding agent run |
-| `REVIEW_MODEL` | `claude-sonnet-4-6` | Model for review agent |
+| `REVIEW_MODEL` | `claude-opus-4-7` | Model for review agent |
 | `NOTIFY_WEBHOOK` | _(empty)_ | Slack/Discord webhook URL |
 | `PARALLEL` | 0 | Set to 1 to use parallel mode |
 
@@ -157,7 +157,7 @@ PARALLEL=1 .dev/run_pipeline.sh
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MAX_PARALLEL` | 3 | Max concurrent agents |
-| `AGENT_MODEL` | `claude-opus-4-6` | Model for parallel coding agents |
+| `AGENT_MODEL` | `claude-opus-4-7` | Model for parallel coding agents |
 
 ## Progress Tracking
 

--- a/.dev/run_agent.sh
+++ b/.dev/run_agent.sh
@@ -93,14 +93,14 @@ while true; do
         # Raw mode: stream-json straight to screen + log
         claude --dangerously-skip-permissions \
                -p "$(cat "${SCRIPT_DIR}/AGENT_PROMPT.md")" \
-               --model claude-opus-4-6 \
+               --model claude-opus-4-7 \
                --output-format stream-json --verbose \
                2>&1 | tee "$LOGFILE" &
     else
         # Formatted mode: raw JSON to log, pretty output to screen
         claude --dangerously-skip-permissions \
                -p "$(cat "${SCRIPT_DIR}/AGENT_PROMPT.md")" \
-               --model claude-opus-4-6 \
+               --model claude-opus-4-7 \
                --output-format stream-json --verbose \
                2>&1 | tee "$LOGFILE" | "$FORMATTER" &
     fi

--- a/.dev/run_parallel.sh
+++ b/.dev/run_parallel.sh
@@ -23,7 +23,7 @@ SUMMARY_LOG="${LOG_DIR}/parallel_summary.log"
 WT_BASE="/tmp/chromeclaw-worktrees"
 
 MAX_PARALLEL="${MAX_PARALLEL:-3}"
-AGENT_MODEL="${AGENT_MODEL:-claude-opus-4-6}"
+AGENT_MODEL="${AGENT_MODEL:-claude-opus-4-7}"
 
 mkdir -p "$LOG_DIR" "$WT_BASE"
 

--- a/.dev/run_pipeline.sh
+++ b/.dev/run_pipeline.sh
@@ -19,7 +19,7 @@ SUMMARY_LOG="${LOG_DIR}/pipeline_summary.log"
 
 MAX_CYCLES="${MAX_CYCLES:-3}"
 AGENT_MAX_ITERATIONS="${AGENT_MAX_ITERATIONS:-10}"  # Budget guard: cap iterations per cycle
-REVIEW_MODEL="${REVIEW_MODEL:-claude-sonnet-4-6}"   # Cheaper model for review (Sonnet vs Opus)
+REVIEW_MODEL="${REVIEW_MODEL:-claude-opus-4-7}"     # Review model
 NOTIFY_WEBHOOK="${NOTIFY_WEBHOOK:-}"                # Optional: Slack/Discord webhook URL for notifications
 
 mkdir -p "$LOG_DIR"

--- a/chrome-extension/src/background/cron/executor.ts
+++ b/chrome-extension/src/background/cron/executor.ts
@@ -1,12 +1,12 @@
 // ── Task executor ───────────────────────────
 // Executes scheduled tasks via headless LLM
 
-import { getChannelAdapter } from '../channels/registry';
-import { getChannelConfigs } from '../channels/config';
 import { runHeadlessLLM, resolveDefaultModel, dbModelToChatModel } from '../agents/agent-setup';
+import { getChannelConfigs } from '../channels/config';
+import { getChannelAdapter } from '../channels/registry';
+import { getHeartbeatServiceRef } from '../heartbeat';
 import { createLogger } from '../logging/logger-buffer';
 import { createKeepAliveManager } from '../utils/keep-alive';
-import { getHeartbeatServiceRef } from '../heartbeat';
 import {
   addMessage,
   getChat,

--- a/chrome-extension/src/background/cron/executor.ts
+++ b/chrome-extension/src/background/cron/executor.ts
@@ -6,6 +6,7 @@ import { getChannelConfigs } from '../channels/config';
 import { runHeadlessLLM, resolveDefaultModel, dbModelToChatModel } from '../agents/agent-setup';
 import { createLogger } from '../logging/logger-buffer';
 import { createKeepAliveManager } from '../utils/keep-alive';
+import { getHeartbeatServiceRef } from '../heartbeat';
 import {
   addMessage,
   getChat,
@@ -77,6 +78,9 @@ const executeScheduledTask = async (task: ScheduledTask): Promise<TaskExecResult
 
   try {
     if (task.payload.kind === 'agentTurn') {
+      if (task.payload.wakeMode === 'heartbeat') {
+        return await executeHeartbeatBridge(task);
+      }
       return await executeAgentTurn(task, controller.signal);
     }
 
@@ -92,6 +96,28 @@ const executeScheduledTask = async (task: ScheduledTask): Promise<TaskExecResult
     clearTimeout(timer);
     cronKeepAlive.release();
   }
+};
+
+const executeHeartbeatBridge = async (task: ScheduledTask): Promise<TaskExecResult> => {
+  if (task.payload.kind !== 'agentTurn' || task.payload.wakeMode !== 'heartbeat') {
+    return { status: 'error', error: 'Expected heartbeat agentTurn payload' };
+  }
+  const svc = getHeartbeatServiceRef();
+  if (!svc) {
+    return { status: 'error', error: 'HeartbeatService not initialized' };
+  }
+  svc.requestHeartbeatNow({
+    reason: `cron:${task.id}`,
+    agentId: task.payload.agentId,
+    sessionKey: task.payload.sessionKey,
+  });
+  cronLog.info('Cron delegated to heartbeat service', {
+    taskId: task.id,
+    agentId: task.payload.agentId,
+  });
+  // Heartbeat runs async; cron fires-and-forgets. 'ok' surfaces success in
+  // the scheduler UI. Failures show up in heartbeat state telemetry.
+  return { status: 'ok' };
 };
 
 const executeAgentTurn = async (

--- a/chrome-extension/src/background/cron/types.ts
+++ b/chrome-extension/src/background/cron/types.ts
@@ -6,11 +6,32 @@ export type TaskSchedule =
   | { kind: 'cron'; expr: string; tz?: string };
 
 export type TaskPayload =
-  | { kind: 'agentTurn'; message: string; model?: string; timeoutMs?: number }
+  | {
+      kind: 'agentTurn';
+      message: string;
+      model?: string;
+      timeoutMs?: number;
+      /**
+       * When 'heartbeat', the cron executor routes this tick through the
+       * heartbeat subsystem (skip/dedup/prune/deliver pipeline) instead of
+       * running a fresh headless LLM turn. `message` is ignored in that mode.
+       */
+      wakeMode?: 'heartbeat';
+      agentId?: string;
+      sessionKey?: string;
+    }
   | { kind: 'chatInject'; chatId: string; message: string };
 
 export type TaskPayloadPatch =
-  | { kind: 'agentTurn'; message?: string; model?: string; timeoutMs?: number }
+  | {
+      kind: 'agentTurn';
+      message?: string;
+      model?: string;
+      timeoutMs?: number;
+      wakeMode?: 'heartbeat';
+      agentId?: string;
+      sessionKey?: string;
+    }
   | { kind: 'chatInject'; chatId?: string; message?: string };
 
 export type TaskDelivery = {

--- a/chrome-extension/src/background/heartbeat/active-hours.test.ts
+++ b/chrome-extension/src/background/heartbeat/active-hours.test.ts
@@ -1,0 +1,99 @@
+// Unit tests for active-hours + reason classification (R20 / 02.24).
+
+import { describe, expect, it } from 'vitest';
+import { isWithinActiveHours } from './active-hours';
+import { classifyReason, isActionLikeReason } from './reason';
+
+describe('isWithinActiveHours', () => {
+  it('returns true when config is missing', () => {
+    expect(isWithinActiveHours(undefined)).toBe(true);
+  });
+
+  it('returns true for malformed time strings (permissive)', () => {
+    expect(
+      isWithinActiveHours({ start: 'nope', end: '25:00', timezone: 'UTC' }),
+    ).toBe(true);
+  });
+
+  it('returns false when start === end (degenerate window)', () => {
+    expect(isWithinActiveHours({ start: '09:00', end: '09:00', timezone: 'UTC' })).toBe(false);
+  });
+
+  it('accepts 24:00 as end-of-day', () => {
+    // A UTC moment at 23:30 should be inside "00:00 - 24:00".
+    const at = Date.UTC(2026, 0, 1, 23, 30);
+    expect(
+      isWithinActiveHours({ start: '00:00', end: '24:00', timezone: 'UTC' }, at),
+    ).toBe(true);
+  });
+
+  it('handles a normal daytime window', () => {
+    const morning = Date.UTC(2026, 0, 1, 10, 0);
+    const night = Date.UTC(2026, 0, 1, 22, 0);
+    expect(
+      isWithinActiveHours({ start: '09:00', end: '18:00', timezone: 'UTC' }, morning),
+    ).toBe(true);
+    expect(
+      isWithinActiveHours({ start: '09:00', end: '18:00', timezone: 'UTC' }, night),
+    ).toBe(false);
+  });
+
+  it('handles wrap-around (night shift) windows', () => {
+    const late = Date.UTC(2026, 0, 1, 23, 30);
+    const early = Date.UTC(2026, 0, 1, 5, 30);
+    const midday = Date.UTC(2026, 0, 1, 12, 0);
+    const cfg = { start: '22:00', end: '06:00', timezone: 'UTC' };
+    expect(isWithinActiveHours(cfg, late)).toBe(true);
+    expect(isWithinActiveHours(cfg, early)).toBe(true);
+    expect(isWithinActiveHours(cfg, midday)).toBe(false);
+  });
+
+  it('falls back to permissive when timezone is invalid', () => {
+    const at = Date.UTC(2026, 0, 1, 12, 0);
+    expect(
+      isWithinActiveHours({ start: '09:00', end: '18:00', timezone: 'Mars/Olympus' }, at),
+    ).toBeTypeOf('boolean');
+  });
+});
+
+describe('classifyReason', () => {
+  it('maps empty / unknown to interval', () => {
+    expect(classifyReason(undefined)).toBe('interval');
+    expect(classifyReason('')).toBe('interval');
+  });
+
+  it('preserves known reasons', () => {
+    expect(classifyReason('manual')).toBe('manual');
+    expect(classifyReason('retry')).toBe('retry');
+    expect(classifyReason('exec-event')).toBe('exec-event');
+    expect(classifyReason('wake')).toBe('wake');
+  });
+
+  it('preserves cron:<detail> and collapses bare cron', () => {
+    expect(classifyReason('cron:abc')).toBe('cron:abc');
+    expect(classifyReason('cron')).toBe('cron:unknown');
+  });
+
+  it('accepts trigger object form', () => {
+    expect(classifyReason({ kind: 'manual' })).toBe('manual');
+  });
+
+  it('falls back to "other" for unrecognized strings', () => {
+    expect(classifyReason('foo')).toBe('other');
+  });
+});
+
+describe('isActionLikeReason', () => {
+  it('treats manual / exec-event / wake / cron:* as action-like', () => {
+    expect(isActionLikeReason('manual')).toBe(true);
+    expect(isActionLikeReason('exec-event')).toBe(true);
+    expect(isActionLikeReason('wake')).toBe(true);
+    expect(isActionLikeReason('cron:job-7')).toBe(true);
+  });
+
+  it('treats interval / retry / other as non-action', () => {
+    expect(isActionLikeReason('interval')).toBe(false);
+    expect(isActionLikeReason('retry')).toBe(false);
+    expect(isActionLikeReason('other')).toBe(false);
+  });
+});

--- a/chrome-extension/src/background/heartbeat/active-hours.test.ts
+++ b/chrome-extension/src/background/heartbeat/active-hours.test.ts
@@ -1,8 +1,8 @@
 // Unit tests for active-hours + reason classification (R20 / 02.24).
 
-import { describe, expect, it } from 'vitest';
 import { isWithinActiveHours } from './active-hours';
 import { classifyReason, isActionLikeReason } from './reason';
+import { describe, expect, it } from 'vitest';
 
 describe('isWithinActiveHours', () => {
   it('returns true when config is missing', () => {
@@ -10,9 +10,7 @@ describe('isWithinActiveHours', () => {
   });
 
   it('returns true for malformed time strings (permissive)', () => {
-    expect(
-      isWithinActiveHours({ start: 'nope', end: '25:00', timezone: 'UTC' }),
-    ).toBe(true);
+    expect(isWithinActiveHours({ start: 'nope', end: '25:00', timezone: 'UTC' })).toBe(true);
   });
 
   it('returns false when start === end (degenerate window)', () => {
@@ -22,20 +20,18 @@ describe('isWithinActiveHours', () => {
   it('accepts 24:00 as end-of-day', () => {
     // A UTC moment at 23:30 should be inside "00:00 - 24:00".
     const at = Date.UTC(2026, 0, 1, 23, 30);
-    expect(
-      isWithinActiveHours({ start: '00:00', end: '24:00', timezone: 'UTC' }, at),
-    ).toBe(true);
+    expect(isWithinActiveHours({ start: '00:00', end: '24:00', timezone: 'UTC' }, at)).toBe(true);
   });
 
   it('handles a normal daytime window', () => {
     const morning = Date.UTC(2026, 0, 1, 10, 0);
     const night = Date.UTC(2026, 0, 1, 22, 0);
-    expect(
-      isWithinActiveHours({ start: '09:00', end: '18:00', timezone: 'UTC' }, morning),
-    ).toBe(true);
-    expect(
-      isWithinActiveHours({ start: '09:00', end: '18:00', timezone: 'UTC' }, night),
-    ).toBe(false);
+    expect(isWithinActiveHours({ start: '09:00', end: '18:00', timezone: 'UTC' }, morning)).toBe(
+      true,
+    );
+    expect(isWithinActiveHours({ start: '09:00', end: '18:00', timezone: 'UTC' }, night)).toBe(
+      false,
+    );
   });
 
   it('handles wrap-around (night shift) windows', () => {

--- a/chrome-extension/src/background/heartbeat/active-hours.ts
+++ b/chrome-extension/src/background/heartbeat/active-hours.ts
@@ -1,0 +1,78 @@
+// ── Active-hours evaluation ─────────────────────
+// Ported from OpenClaw's `heartbeat-active-hours.ts`, adapted for the
+// extension: no OpenClaw `cfg` dependency — takes a plain
+// `HeartbeatConfig.activeHours` object directly.
+
+import type { HeartbeatActiveHoursConfig } from './types';
+
+const ACTIVE_HOURS_TIME_PATTERN = /^(?:([01]\d|2[0-3]):([0-5]\d)|24:00)$/;
+
+const parseTimeToMinutes = (opts: { allow24: boolean }, raw?: string): number | null => {
+  if (!raw || !ACTIVE_HOURS_TIME_PATTERN.test(raw)) return null;
+  const [hourStr, minuteStr] = raw.split(':');
+  const hour = Number(hourStr);
+  const minute = Number(minuteStr);
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
+  if (hour === 24) {
+    if (!opts.allow24 || minute !== 0) return null;
+    return 24 * 60;
+  }
+  return hour * 60 + minute;
+};
+
+const resolveTimezone = (raw?: string): string => {
+  const trimmed = raw?.trim();
+  if (!trimmed || trimmed === 'user' || trimmed === 'local') {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  }
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: trimmed }).format(new Date());
+    return trimmed;
+  } catch {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  }
+};
+
+const minutesInZone = (nowMs: number, timeZone: string): number | null => {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(new Date(nowMs));
+    const map: Record<string, string> = {};
+    for (const p of parts) if (p.type !== 'literal') map[p.type] = p.value;
+    const hour = Number(map.hour);
+    const minute = Number(map.minute);
+    if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
+    return hour * 60 + minute;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Returns true if `nowMs` (default: Date.now()) falls within the configured
+ * active hours. Missing / malformed config → permissive (true).
+ */
+const isWithinActiveHours = (
+  active: HeartbeatActiveHoursConfig | undefined,
+  nowMs?: number,
+): boolean => {
+  if (!active) return true;
+
+  const startMin = parseTimeToMinutes({ allow24: false }, active.start);
+  const endMin = parseTimeToMinutes({ allow24: true }, active.end);
+  if (startMin === null || endMin === null) return true;
+  if (startMin === endMin) return false;
+
+  const timeZone = resolveTimezone(active.timezone);
+  const currentMin = minutesInZone(nowMs ?? Date.now(), timeZone);
+  if (currentMin === null) return true;
+
+  if (endMin > startMin) return currentMin >= startMin && currentMin < endMin;
+  return currentMin >= startMin || currentMin < endMin;
+};
+
+export { isWithinActiveHours };

--- a/chrome-extension/src/background/heartbeat/config.test.ts
+++ b/chrome-extension/src/background/heartbeat/config.test.ts
@@ -1,0 +1,157 @@
+// Unit tests for heartbeat config resolver (phase 03).
+//
+// Mirrors OpenClaw's `isHeartbeatEnabledForAgent` + `resolveHeartbeatConfig`:
+//
+//   Rule 1: If any agent has an explicit `heartbeat.<id>` entry in
+//           chrome.storage.local, semantics are opt-in — only agents whose
+//           explicit config has `enabled: true` run.
+//   Rule 2: Otherwise, the default agent (isDefault=1 in the agents table)
+//           runs with `enabled: true` + `every: DEFAULT_HEARTBEAT_EVERY`.
+//           Non-default agents are disabled.
+//   Rule 3: `heartbeat.defaults` merges under per-agent explicit config
+//           (per-agent wins on conflicting keys).
+
+import { DEFAULTS_KEY, agentKey, isHeartbeatEnabledForAgent, loadHeartbeatConfig } from './config';
+import { DEFAULT_HEARTBEAT_EVERY } from './prompt';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// ── Minimal chrome.storage.local stub ──────────────
+// Must be installed BEFORE importing `@extension/storage`, which builds
+// liveUpdate listeners on chrome.storage.local.onChanged.
+const chromeStore: Record<string, unknown> = {};
+const chromeListeners = new Set<() => void>();
+const installChromeStub = (): Record<string, unknown> => {
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    storage: {
+      local: {
+        get: async (key: string | string[] | Record<string, unknown> | null) => {
+          if (key == null) return { ...chromeStore };
+          if (typeof key === 'string') return { [key]: chromeStore[key] };
+          if (Array.isArray(key)) {
+            const out: Record<string, unknown> = {};
+            for (const k of key) out[k] = chromeStore[k];
+            return out;
+          }
+          return { ...key, ...chromeStore };
+        },
+        set: async (rec: Record<string, unknown>) => {
+          Object.assign(chromeStore, rec);
+        },
+        remove: async (key: string) => {
+          delete chromeStore[key];
+        },
+        clear: async () => {
+          for (const k of Object.keys(chromeStore)) delete chromeStore[k];
+        },
+        onChanged: {
+          addListener: (fn: () => void) => chromeListeners.add(fn),
+          removeListener: (fn: () => void) => chromeListeners.delete(fn),
+        },
+      },
+      session: {
+        get: async () => ({}),
+        set: async () => {},
+        remove: async () => {},
+      },
+    },
+  };
+  return chromeStore;
+};
+installChromeStub();
+
+describe('heartbeat config resolver', () => {
+  const store = chromeStore;
+
+  beforeEach(async () => {
+    for (const k of Object.keys(store)) delete store[k];
+    const { chatDb } = await import('@extension/storage');
+    await chatDb.agents.clear();
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(store)) delete store[k];
+  });
+
+  const putAgent = async (id: string, isDefault: boolean): Promise<void> => {
+    const { chatDb } = await import('@extension/storage');
+    await chatDb.agents.put({
+      id,
+      name: id,
+      identity: '',
+      model: undefined,
+      toolConfig: {},
+      customTools: [],
+      isDefault: (isDefault ? 1 : 0) as unknown as boolean,
+      createdAt: 0,
+      updatedAt: 0,
+    } as never);
+  };
+
+  it('rule 2: no explicit configs → default agent is enabled', async () => {
+    await putAgent('main', true);
+    await putAgent('other', false);
+
+    expect(await isHeartbeatEnabledForAgent('main')).toBe(true);
+    const cfg = await loadHeartbeatConfig('main');
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.every).toBe(DEFAULT_HEARTBEAT_EVERY);
+  });
+
+  it('rule 2: no explicit configs → non-default agent is disabled', async () => {
+    await putAgent('main', true);
+    await putAgent('other', false);
+
+    expect(await isHeartbeatEnabledForAgent('other')).toBe(false);
+    const cfg = await loadHeartbeatConfig('other');
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it('rule 1: explicit config for non-default agent flips semantics to opt-in (default agent becomes disabled)', async () => {
+    await putAgent('main', true);
+    await putAgent('other', false);
+    store[agentKey('other')] = { enabled: true };
+
+    expect(await isHeartbeatEnabledForAgent('other')).toBe(true);
+    expect(await isHeartbeatEnabledForAgent('main')).toBe(false);
+
+    const mainCfg = await loadHeartbeatConfig('main');
+    expect(mainCfg.enabled).toBe(false);
+
+    const otherCfg = await loadHeartbeatConfig('other');
+    expect(otherCfg.enabled).toBe(true);
+  });
+
+  it('rule 1: explicit disabled config counts as explicit (flips semantics)', async () => {
+    await putAgent('main', true);
+    await putAgent('other', false);
+    // User explicitly opted default agent out
+    store[agentKey('main')] = { enabled: false };
+
+    expect(await isHeartbeatEnabledForAgent('main')).toBe(false);
+    expect(await isHeartbeatEnabledForAgent('other')).toBe(false);
+  });
+
+  it('rule 3: heartbeat.defaults merges under explicit per-agent config; per-agent wins', async () => {
+    await putAgent('main', true);
+    store[DEFAULTS_KEY] = { every: '15m', ackMaxChars: 500, target: 'none' };
+    store[agentKey('main')] = { enabled: true, every: '5m' };
+
+    const cfg = await loadHeartbeatConfig('main');
+    expect(cfg.enabled).toBe(true);
+    // per-agent override wins on `every`
+    expect(cfg.every).toBe('5m');
+    // merged from defaults
+    expect(cfg.ackMaxChars).toBe(500);
+    expect(cfg.target).toBe('none');
+  });
+
+  it('rule 2 + defaults merge: default agent gets defaults merged in even without per-agent config', async () => {
+    await putAgent('main', true);
+    store[DEFAULTS_KEY] = { every: '10m' };
+
+    const cfg = await loadHeartbeatConfig('main');
+    expect(cfg.enabled).toBe(true);
+    // defaults override built-in every
+    expect(cfg.every).toBe('10m');
+  });
+});

--- a/chrome-extension/src/background/heartbeat/config.ts
+++ b/chrome-extension/src/background/heartbeat/config.ts
@@ -1,14 +1,30 @@
 // ── Config resolution ───────────────────────────
 // Per-agent heartbeat config is stored in `chrome.storage.local` under
-// `heartbeat.<agentId>`. Defaults live at `heartbeat.defaults`. Loading an
-// unknown agent returns the defaults with `enabled: false` so the subsystem
-// opts in explicitly.
+// `heartbeat.<agentId>`. Defaults live at `heartbeat.defaults`.
+//
+// Enablement follows OpenClaw's two-rule resolver (see
+// `/src/infra/heartbeat-runner.ts isHeartbeatEnabledForAgent`):
+//
+//   Rule 1 — Explicit opt-in mode: if ANY agent has a `heartbeat.<id>`
+//            entry in chrome.storage.local (whether enabled: true or false),
+//            semantics flip to opt-in. Only agents whose explicit config has
+//            `enabled: true` run; all other agents — including the default
+//            one — are disabled.
+//   Rule 2 — Implicit default mode: when no explicit per-agent configs
+//            exist, the agent flagged as `isDefault=1` in the agents table
+//            runs with `enabled: true` + DEFAULT_HEARTBEAT_EVERY. Non-default
+//            agents stay disabled.
+//
+// `heartbeat.defaults` merges beneath explicit per-agent config; per-agent
+// keys win on conflict.
 
 import { DEFAULT_HEARTBEAT_EVERY, DEFAULT_HEARTBEAT_ACK_MAX_CHARS } from './prompt';
+import { getDefaultAgent, getAgent, listAgents } from '@extension/storage';
 import type { HeartbeatConfig } from './types';
 
 const DEFAULTS_KEY = 'heartbeat.defaults';
-const agentKey = (agentId: string): string => `heartbeat.${agentId}`;
+const AGENT_KEY_PREFIX = 'heartbeat.';
+const agentKey = (agentId: string): string => `${AGENT_KEY_PREFIX}${agentId}`;
 
 const BUILT_IN_DEFAULTS: HeartbeatConfig = {
   enabled: false,
@@ -36,6 +52,41 @@ const setLocal = async (key: string, value: Partial<HeartbeatConfig>): Promise<v
   }
 };
 
+/** Return every `heartbeat.<agentId>` entry currently in local storage. */
+const getExplicitAgentConfigs = async (): Promise<Record<string, Partial<HeartbeatConfig>>> => {
+  try {
+    const record = await chrome.storage.local.get(null as unknown as string);
+    const out: Record<string, Partial<HeartbeatConfig>> = {};
+    if (record && typeof record === 'object') {
+      for (const [key, value] of Object.entries(record)) {
+        if (!key.startsWith(AGENT_KEY_PREFIX)) continue;
+        if (key === DEFAULTS_KEY) continue;
+        if (value && typeof value === 'object') {
+          out[key.slice(AGENT_KEY_PREFIX.length)] = value as Partial<HeartbeatConfig>;
+        }
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+};
+
+const resolveDefaultAgentId = async (): Promise<string | undefined> => {
+  try {
+    // Primary: look for agent with isDefault flag
+    const agent = await getDefaultAgent();
+    if (agent) return agent.id;
+    // Fallback: if no agent has isDefault set (stale DB), try 'main' or first agent
+    const main = await getAgent('main');
+    if (main) return main.id;
+    const all = await listAgents();
+    return all[0]?.id;
+  } catch {
+    return undefined;
+  }
+};
+
 /** Load the global defaults, merged on top of the built-ins. */
 const loadHeartbeatDefaults = async (): Promise<HeartbeatConfig> => {
   const stored = await getLocal(DEFAULTS_KEY);
@@ -43,13 +94,45 @@ const loadHeartbeatDefaults = async (): Promise<HeartbeatConfig> => {
 };
 
 /**
- * Load per-agent config; missing rows fall back to defaults. The returned
- * config is fully populated (never undefined `every` / `ackMaxChars`).
+ * Return true when the heartbeat should run for this agent, following the
+ * two-rule resolver documented at the top of this file.
+ */
+const isHeartbeatEnabledForAgent = async (agentId: string): Promise<boolean> => {
+  const explicit = await getExplicitAgentConfigs();
+  const explicitIds = Object.keys(explicit);
+  if (explicitIds.length > 0) {
+    // Rule 1: opt-in mode — only enabled if this agent has an explicit entry
+    // whose `enabled` is truthy.
+    const entry = explicit[agentId];
+    return Boolean(entry && entry.enabled === true);
+  }
+  // Rule 2: implicit mode — only the default agent runs (with fallback).
+  const defaultAgentId = await resolveDefaultAgentId();
+  return defaultAgentId !== undefined && defaultAgentId === agentId;
+};
+
+/**
+ * Load per-agent config, merging `heartbeat.defaults` under explicit per-agent
+ * overrides. `enabled` is resolved through {@link isHeartbeatEnabledForAgent}
+ * so the default agent gets `enabled: true` out of the box while non-default
+ * agents stay off unless they opt in.
  */
 const loadHeartbeatConfig = async (agentId: string): Promise<HeartbeatConfig> => {
-  const defaults = await loadHeartbeatDefaults();
-  const stored = await getLocal(agentKey(agentId));
-  return { ...defaults, ...(stored ?? {}) } as HeartbeatConfig;
+  const [defaults, explicit] = await Promise.all([
+    loadHeartbeatDefaults(),
+    getExplicitAgentConfigs(),
+  ]);
+  const stored = explicit[agentId];
+  const merged = { ...defaults, ...(stored ?? {}) } as HeartbeatConfig;
+  const explicitIds = Object.keys(explicit);
+  let resolvedDefaultId: string | undefined;
+  if (explicitIds.length > 0) {
+    merged.enabled = Boolean(stored && stored.enabled === true);
+  } else {
+    resolvedDefaultId = await resolveDefaultAgentId();
+    merged.enabled = resolvedDefaultId === agentId;
+  }
+  return merged;
 };
 
 const saveHeartbeatConfig = async (agentId: string, cfg: Partial<HeartbeatConfig>): Promise<void> =>
@@ -62,6 +145,7 @@ export {
   DEFAULTS_KEY,
   BUILT_IN_DEFAULTS,
   agentKey,
+  isHeartbeatEnabledForAgent,
   loadHeartbeatConfig,
   loadHeartbeatDefaults,
   saveHeartbeatConfig,

--- a/chrome-extension/src/background/heartbeat/config.ts
+++ b/chrome-extension/src/background/heartbeat/config.ts
@@ -1,0 +1,69 @@
+// ── Config resolution ───────────────────────────
+// Per-agent heartbeat config is stored in `chrome.storage.local` under
+// `heartbeat.<agentId>`. Defaults live at `heartbeat.defaults`. Loading an
+// unknown agent returns the defaults with `enabled: false` so the subsystem
+// opts in explicitly.
+
+import { DEFAULT_HEARTBEAT_EVERY, DEFAULT_HEARTBEAT_ACK_MAX_CHARS } from './prompt';
+import type { HeartbeatConfig } from './types';
+
+const DEFAULTS_KEY = 'heartbeat.defaults';
+const agentKey = (agentId: string): string => `heartbeat.${agentId}`;
+
+const BUILT_IN_DEFAULTS: HeartbeatConfig = {
+  enabled: false,
+  every: DEFAULT_HEARTBEAT_EVERY,
+  ackMaxChars: DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  target: 'last',
+};
+
+const getLocal = async (key: string): Promise<Partial<HeartbeatConfig> | undefined> => {
+  try {
+    const record = await chrome.storage.local.get(key);
+    const raw = record?.[key];
+    if (raw && typeof raw === 'object') return raw as Partial<HeartbeatConfig>;
+  } catch {
+    /* storage unavailable (e.g. in tests) */
+  }
+  return undefined;
+};
+
+const setLocal = async (key: string, value: Partial<HeartbeatConfig>): Promise<void> => {
+  try {
+    await chrome.storage.local.set({ [key]: value });
+  } catch {
+    /* best-effort */
+  }
+};
+
+/** Load the global defaults, merged on top of the built-ins. */
+const loadHeartbeatDefaults = async (): Promise<HeartbeatConfig> => {
+  const stored = await getLocal(DEFAULTS_KEY);
+  return { ...BUILT_IN_DEFAULTS, ...(stored ?? {}) } as HeartbeatConfig;
+};
+
+/**
+ * Load per-agent config; missing rows fall back to defaults. The returned
+ * config is fully populated (never undefined `every` / `ackMaxChars`).
+ */
+const loadHeartbeatConfig = async (agentId: string): Promise<HeartbeatConfig> => {
+  const defaults = await loadHeartbeatDefaults();
+  const stored = await getLocal(agentKey(agentId));
+  return { ...defaults, ...(stored ?? {}) } as HeartbeatConfig;
+};
+
+const saveHeartbeatConfig = async (agentId: string, cfg: Partial<HeartbeatConfig>): Promise<void> =>
+  setLocal(agentKey(agentId), cfg);
+
+const saveHeartbeatDefaults = async (cfg: Partial<HeartbeatConfig>): Promise<void> =>
+  setLocal(DEFAULTS_KEY, cfg);
+
+export {
+  DEFAULTS_KEY,
+  BUILT_IN_DEFAULTS,
+  agentKey,
+  loadHeartbeatConfig,
+  loadHeartbeatDefaults,
+  saveHeartbeatConfig,
+  saveHeartbeatDefaults,
+};

--- a/chrome-extension/src/background/heartbeat/events.ts
+++ b/chrome-extension/src/background/heartbeat/events.ts
@@ -1,0 +1,34 @@
+// ── In-memory pub/sub for heartbeat events ──────
+// Background service worker only: listeners are ephemeral and die with the
+// worker, just like the events themselves.
+
+import type { HeartbeatEvent } from './types';
+
+type HeartbeatListener = (event: HeartbeatEvent) => void;
+
+const listeners = new Set<HeartbeatListener>();
+
+/** Register a listener. Returns an unsubscribe function. */
+const onHeartbeatEvent = (listener: HeartbeatListener): (() => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+/** Fire an event to all listeners; individual listener errors are isolated. */
+const emitHeartbeatEvent = (event: HeartbeatEvent): void => {
+  for (const l of [...listeners]) {
+    try {
+      l(event);
+    } catch {
+      /* ignore */
+    }
+  }
+};
+
+/** Test-only helper to drop all registered listeners. */
+const _resetHeartbeatListeners = (): void => {
+  listeners.clear();
+};
+
+export { onHeartbeatEvent, emitHeartbeatEvent, _resetHeartbeatListeners };
+export type { HeartbeatListener };

--- a/chrome-extension/src/background/heartbeat/index.ts
+++ b/chrome-extension/src/background/heartbeat/index.ts
@@ -1,0 +1,29 @@
+// ── Heartbeat subsystem public API ──────────────
+// Consumers (SW entry, cron bridge, UI) import from this barrel only. Keeping
+// the surface narrow lets internal reshuffles happen without ripple edits.
+
+export { HeartbeatService } from './service';
+export { setHeartbeatServiceRef, getHeartbeatServiceRef } from './ref';
+export {
+  HEARTBEAT_ALARM_NAME,
+  HEARTBEAT_KICK_ALARM_NAME,
+  isSchedulerAlarm,
+  scheduleTick,
+  scheduleKick,
+} from './service/timer';
+export { onHeartbeatEvent } from './events';
+export {
+  loadHeartbeatConfig,
+  loadHeartbeatDefaults,
+  saveHeartbeatConfig,
+  saveHeartbeatDefaults,
+} from './config';
+export type {
+  HeartbeatConfig,
+  HeartbeatEvent,
+  HeartbeatReason,
+  HeartbeatRunResult,
+  HeartbeatTrigger,
+  HeartbeatActiveHoursConfig,
+  HeartbeatVisibilityConfig,
+} from './types';

--- a/chrome-extension/src/background/heartbeat/index.ts
+++ b/chrome-extension/src/background/heartbeat/index.ts
@@ -13,6 +13,7 @@ export {
 } from './service/timer';
 export { onHeartbeatEvent } from './events';
 export {
+  isHeartbeatEnabledForAgent,
   loadHeartbeatConfig,
   loadHeartbeatDefaults,
   saveHeartbeatConfig,

--- a/chrome-extension/src/background/heartbeat/prompt.test.ts
+++ b/chrome-extension/src/background/heartbeat/prompt.test.ts
@@ -1,6 +1,5 @@
 // Unit tests for heartbeat prompt helpers (R20 / 02.27).
 
-import { describe, expect, it } from 'vitest';
 import {
   HEARTBEAT_TOKEN,
   isHeartbeatContentEffectivelyEmpty,
@@ -8,6 +7,7 @@ import {
   stripHeartbeatToken,
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
 } from './prompt';
+import { describe, expect, it } from 'vitest';
 
 describe('isHeartbeatContentEffectivelyEmpty', () => {
   it('treats missing / whitespace-only content as empty', () => {
@@ -16,9 +16,7 @@ describe('isHeartbeatContentEffectivelyEmpty', () => {
   });
 
   it('skips markdown headers and empty list markers', () => {
-    expect(
-      isHeartbeatContentEffectivelyEmpty('# Heading\n\n## Sub\n\n- [ ]\n* '),
-    ).toBe(true);
+    expect(isHeartbeatContentEffectivelyEmpty('# Heading\n\n## Sub\n\n- [ ]\n* ')).toBe(true);
   });
 
   it('detects real content', () => {
@@ -26,9 +24,9 @@ describe('isHeartbeatContentEffectivelyEmpty', () => {
     expect(isHeartbeatContentEffectivelyEmpty('remind me in 5m')).toBe(false);
   });
 
-  it('returns false for null / undefined (LLM decides)', () => {
-    expect(isHeartbeatContentEffectivelyEmpty(undefined)).toBe(false);
-    expect(isHeartbeatContentEffectivelyEmpty(null)).toBe(false);
+  it('returns true for null / undefined (missing file = empty)', () => {
+    expect(isHeartbeatContentEffectivelyEmpty(undefined)).toBe(true);
+    expect(isHeartbeatContentEffectivelyEmpty(null)).toBe(true);
   });
 });
 

--- a/chrome-extension/src/background/heartbeat/prompt.test.ts
+++ b/chrome-extension/src/background/heartbeat/prompt.test.ts
@@ -1,0 +1,85 @@
+// Unit tests for heartbeat prompt helpers (R20 / 02.27).
+
+import { describe, expect, it } from 'vitest';
+import {
+  HEARTBEAT_TOKEN,
+  isHeartbeatContentEffectivelyEmpty,
+  resolveHeartbeatPrompt,
+  stripHeartbeatToken,
+  DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+} from './prompt';
+
+describe('isHeartbeatContentEffectivelyEmpty', () => {
+  it('treats missing / whitespace-only content as empty', () => {
+    expect(isHeartbeatContentEffectivelyEmpty('')).toBe(true);
+    expect(isHeartbeatContentEffectivelyEmpty('   \n  \n')).toBe(true);
+  });
+
+  it('skips markdown headers and empty list markers', () => {
+    expect(
+      isHeartbeatContentEffectivelyEmpty('# Heading\n\n## Sub\n\n- [ ]\n* '),
+    ).toBe(true);
+  });
+
+  it('detects real content', () => {
+    expect(isHeartbeatContentEffectivelyEmpty('- [ ] do the thing')).toBe(false);
+    expect(isHeartbeatContentEffectivelyEmpty('remind me in 5m')).toBe(false);
+  });
+
+  it('returns false for null / undefined (LLM decides)', () => {
+    expect(isHeartbeatContentEffectivelyEmpty(undefined)).toBe(false);
+    expect(isHeartbeatContentEffectivelyEmpty(null)).toBe(false);
+  });
+});
+
+describe('resolveHeartbeatPrompt', () => {
+  it('uses default on empty input', () => {
+    expect(resolveHeartbeatPrompt()).toMatch(/HEARTBEAT_OK/);
+    expect(resolveHeartbeatPrompt('   ')).toMatch(/HEARTBEAT_OK/);
+  });
+  it('keeps a custom prompt trimmed', () => {
+    expect(resolveHeartbeatPrompt('  custom  ')).toBe('custom');
+  });
+});
+
+describe('stripHeartbeatToken', () => {
+  it('reports shouldSkip for plain ack', () => {
+    const r = stripHeartbeatToken(HEARTBEAT_TOKEN);
+    expect(r.shouldSkip).toBe(true);
+    expect(r.didStrip).toBe(true);
+  });
+
+  it('strips HTML-wrapped ack', () => {
+    const r = stripHeartbeatToken(`<b>${HEARTBEAT_TOKEN}</b>`);
+    expect(r.shouldSkip).toBe(true);
+    expect(r.didStrip).toBe(true);
+  });
+
+  it('strips markdown-wrapped ack', () => {
+    const r = stripHeartbeatToken(`**${HEARTBEAT_TOKEN}**`, { mode: 'heartbeat' });
+    expect(r.shouldSkip).toBe(true);
+    expect(r.didStrip).toBe(true);
+  });
+
+  it('keeps text when token is followed by long content in heartbeat mode', () => {
+    const longBody = 'x'.repeat(DEFAULT_HEARTBEAT_ACK_MAX_CHARS + 50);
+    const r = stripHeartbeatToken(`${HEARTBEAT_TOKEN}\n${longBody}`, {
+      mode: 'heartbeat',
+    });
+    expect(r.shouldSkip).toBe(false);
+    expect(r.text).toContain('x');
+    expect(r.didStrip).toBe(true);
+  });
+
+  it('skips trailing punctuation after token', () => {
+    const r = stripHeartbeatToken(`${HEARTBEAT_TOKEN}!!!`, { mode: 'heartbeat' });
+    expect(r.shouldSkip).toBe(true);
+  });
+
+  it('returns original text when token absent', () => {
+    const r = stripHeartbeatToken('just a normal response');
+    expect(r.didStrip).toBe(false);
+    expect(r.shouldSkip).toBe(false);
+    expect(r.text).toBe('just a normal response');
+  });
+});

--- a/chrome-extension/src/background/heartbeat/prompt.ts
+++ b/chrome-extension/src/background/heartbeat/prompt.ts
@@ -1,0 +1,155 @@
+// ── Heartbeat prompt + token utilities ──────────
+// Ported from OpenClaw's `src/auto-reply/heartbeat.ts` and `tokens.ts`.
+//
+// Responsibilities:
+//  - Provide the default heartbeat prompt sent to the LLM on each tick.
+//  - Strip the `HEARTBEAT_OK` sentinel from model output so we never deliver it.
+//  - Decide if a given HEARTBEAT.md file has any actionable content at all.
+
+const HEARTBEAT_TOKEN = 'HEARTBEAT_OK';
+
+const HEARTBEAT_PROMPT =
+  'Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. ' +
+  'Do not infer or repeat old tasks from prior chats. ' +
+  `If nothing needs attention, reply ${HEARTBEAT_TOKEN}.`;
+
+const DEFAULT_HEARTBEAT_EVERY = '30m';
+const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
+
+/** Escape a value so it can be embedded literally inside a RegExp. */
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Returns true iff the HEARTBEAT.md content has no actionable lines. Used to
+ * short-circuit interval ticks when the file is a placeholder.
+ */
+const isHeartbeatContentEffectivelyEmpty = (content: string | undefined | null): boolean => {
+  if (content === undefined || content === null) return false;
+  if (typeof content !== 'string') return false;
+
+  const lines = content.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    // ATX markdown headers (#, ##, ...).
+    if (/^#+(\s|$)/.test(trimmed)) continue;
+    // Empty list items: "- ", "* [ ]", "+ [x]".
+    if (/^[-*+]\s*(\[[\sXx]?\]\s*)?$/.test(trimmed)) continue;
+    return false;
+  }
+  return true;
+};
+
+/** Prefer the user-supplied prompt; fall back to the default. */
+const resolveHeartbeatPrompt = (raw?: string): string => {
+  const trimmed = typeof raw === 'string' ? raw.trim() : '';
+  return trimmed || HEARTBEAT_PROMPT;
+};
+
+type StripHeartbeatMode = 'heartbeat' | 'message';
+
+interface StripHeartbeatResult {
+  shouldSkip: boolean;
+  text: string;
+  didStrip: boolean;
+}
+
+const stripTokenAtEdges = (raw: string): { text: string; didStrip: boolean } => {
+  let text = raw.trim();
+  if (!text) return { text: '', didStrip: false };
+
+  const token = HEARTBEAT_TOKEN;
+  const tokenAtEndWithOptionalTrailingPunctuation = new RegExp(
+    `${escapeRegExp(token)}[^\\w]{0,4}$`,
+  );
+  if (!text.includes(token)) return { text, didStrip: false };
+
+  let didStrip = false;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const next = text.trim();
+    if (next.startsWith(token)) {
+      text = next.slice(token.length).trimStart();
+      didStrip = true;
+      changed = true;
+      continue;
+    }
+    if (tokenAtEndWithOptionalTrailingPunctuation.test(next)) {
+      const idx = next.lastIndexOf(token);
+      const before = next.slice(0, idx).trimEnd();
+      if (!before) {
+        text = '';
+      } else {
+        const after = next.slice(idx + token.length).trimStart();
+        text = `${before}${after}`.trimEnd();
+      }
+      didStrip = true;
+      changed = true;
+    }
+  }
+
+  return { text: text.replace(/\s+/g, ' ').trim(), didStrip };
+};
+
+/**
+ * Strip the heartbeat acknowledgment token from model output.
+ *
+ * In `heartbeat` mode, if after stripping the remainder is within
+ * `maxAckChars`, the whole response counts as an OK and `shouldSkip`
+ * becomes true. In `message` mode the token is simply removed.
+ */
+const stripHeartbeatToken = (
+  raw?: string,
+  opts: { mode?: StripHeartbeatMode; maxAckChars?: number } = {},
+): StripHeartbeatResult => {
+  if (!raw) return { shouldSkip: true, text: '', didStrip: false };
+  const trimmed = raw.trim();
+  if (!trimmed) return { shouldSkip: true, text: '', didStrip: false };
+
+  const mode: StripHeartbeatMode = opts.mode ?? 'message';
+  const parsedAckChars =
+    typeof opts.maxAckChars === 'string' ? Number(opts.maxAckChars) : opts.maxAckChars;
+  const maxAckChars = Math.max(
+    0,
+    typeof parsedAckChars === 'number' && Number.isFinite(parsedAckChars)
+      ? parsedAckChars
+      : DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  );
+
+  const stripMarkup = (text: string): string =>
+    text
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/^[*`~_]+/, '')
+      .replace(/[*`~_]+$/, '');
+
+  const trimmedNormalized = stripMarkup(trimmed);
+  const hasToken = trimmed.includes(HEARTBEAT_TOKEN) || trimmedNormalized.includes(HEARTBEAT_TOKEN);
+  if (!hasToken) return { shouldSkip: false, text: trimmed, didStrip: false };
+
+  const strippedOriginal = stripTokenAtEdges(trimmed);
+  const strippedNormalized = stripTokenAtEdges(trimmedNormalized);
+  const picked =
+    strippedOriginal.didStrip && strippedOriginal.text ? strippedOriginal : strippedNormalized;
+  if (!picked.didStrip) return { shouldSkip: false, text: trimmed, didStrip: false };
+
+  if (!picked.text) return { shouldSkip: true, text: '', didStrip: true };
+
+  const rest = picked.text.trim();
+  if (mode === 'heartbeat' && rest.length <= maxAckChars) {
+    return { shouldSkip: true, text: '', didStrip: true };
+  }
+  return { shouldSkip: false, text: rest, didStrip: true };
+};
+
+export {
+  HEARTBEAT_TOKEN,
+  HEARTBEAT_PROMPT,
+  DEFAULT_HEARTBEAT_EVERY,
+  DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  isHeartbeatContentEffectivelyEmpty,
+  resolveHeartbeatPrompt,
+  stripHeartbeatToken,
+};
+export type { StripHeartbeatMode, StripHeartbeatResult };

--- a/chrome-extension/src/background/heartbeat/prompt.ts
+++ b/chrome-extension/src/background/heartbeat/prompt.ts
@@ -24,7 +24,7 @@ const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\
  * short-circuit interval ticks when the file is a placeholder.
  */
 const isHeartbeatContentEffectivelyEmpty = (content: string | undefined | null): boolean => {
-  if (content === undefined || content === null) return false;
+  if (content === undefined || content === null) return true;
   if (typeof content !== 'string') return false;
 
   const lines = content.split('\n');

--- a/chrome-extension/src/background/heartbeat/reason.ts
+++ b/chrome-extension/src/background/heartbeat/reason.ts
@@ -1,0 +1,36 @@
+// ── Heartbeat reason / trigger classification ────
+// Ported from OpenClaw's `heartbeat-reason.ts`. Simplified: we don't need the
+// full taxonomy here — just a normalized kind used by the runner to decide
+// between skip policies.
+
+import type { HeartbeatReason, HeartbeatTrigger } from './types';
+
+const trimReason = (raw?: string): string => (typeof raw === 'string' ? raw.trim() : '');
+
+/**
+ * Classify a raw trigger string into a normalized reason. Unknown / empty
+ * triggers collapse to `'interval'` so the subsystem degrades to the safest
+ * path (skip-when-empty).
+ */
+const classifyReason = (trigger?: HeartbeatTrigger | string): HeartbeatReason => {
+  const raw = typeof trigger === 'string' ? trigger : trigger?.kind;
+  const trimmed = trimReason(raw);
+  if (!trimmed) return 'interval';
+  if (trimmed === 'interval') return 'interval';
+  if (trimmed === 'manual') return 'manual';
+  if (trimmed === 'retry') return 'retry';
+  if (trimmed === 'exec-event') return 'exec-event';
+  if (trimmed === 'wake') return 'wake';
+  if (trimmed.startsWith('cron:')) return trimmed as HeartbeatReason;
+  if (trimmed === 'cron') return 'cron:unknown';
+  return 'other';
+};
+
+/** True for reasons that bypass the "empty HEARTBEAT.md" short-circuit. */
+const isActionLikeReason = (reason: HeartbeatReason): boolean =>
+  reason === 'manual' ||
+  reason === 'exec-event' ||
+  reason === 'wake' ||
+  reason.startsWith('cron:');
+
+export { classifyReason, isActionLikeReason };

--- a/chrome-extension/src/background/heartbeat/reason.ts
+++ b/chrome-extension/src/background/heartbeat/reason.ts
@@ -28,9 +28,6 @@ const classifyReason = (trigger?: HeartbeatTrigger | string): HeartbeatReason =>
 
 /** True for reasons that bypass the "empty HEARTBEAT.md" short-circuit. */
 const isActionLikeReason = (reason: HeartbeatReason): boolean =>
-  reason === 'manual' ||
-  reason === 'exec-event' ||
-  reason === 'wake' ||
-  reason.startsWith('cron:');
+  reason === 'manual' || reason === 'exec-event' || reason === 'wake' || reason.startsWith('cron:');
 
 export { classifyReason, isActionLikeReason };

--- a/chrome-extension/src/background/heartbeat/ref.ts
+++ b/chrome-extension/src/background/heartbeat/ref.ts
@@ -1,0 +1,17 @@
+// ── Service ref ─────────────────────────────────
+// Module-level singleton accessor for the HeartbeatService. The SW entry
+// (`background/index.ts`) wires the instance here; other subsystems (cron
+// executor) read via `getHeartbeatServiceRef()` without forcing a cyclic
+// import on the service class.
+
+import type { HeartbeatService } from './service';
+
+let ref: HeartbeatService | null = null;
+
+const setHeartbeatServiceRef = (svc: HeartbeatService | null): void => {
+  ref = svc;
+};
+
+const getHeartbeatServiceRef = (): HeartbeatService | null => ref;
+
+export { setHeartbeatServiceRef, getHeartbeatServiceRef };

--- a/chrome-extension/src/background/heartbeat/service.ts
+++ b/chrome-extension/src/background/heartbeat/service.ts
@@ -13,7 +13,9 @@
 // delivery / channel dispatch (see `AgentsPanel` + channel bridges),
 // config persistence (see `config.ts`).
 
-import { loadHeartbeatConfig } from './config';
+import { isHeartbeatEnabledForAgent, loadHeartbeatConfig } from './config';
+import { emitHeartbeatEvent } from './events';
+import { classifyReason } from './reason';
 import { runHeartbeatOnce } from './service/run-once';
 import { createInitialState } from './service/state';
 import {
@@ -169,15 +171,14 @@ class HeartbeatService {
 
   private async runDueAgents(): Promise<void> {
     const nowMs = this.state.deps.nowMs();
-    for (const agent of this.state.agents.values()) {
-      if (agent.inFlight) continue;
-      if (agent.nextDueMs > nowMs) continue;
-      // Fire through the wake queue so concurrent manual requests coalesce.
-      this.wake.requestHeartbeatNow({
-        reason: 'interval',
-        agentId: agent.agentId,
-      });
-    }
+    const candidates = [...this.state.agents.values()].filter(
+      a => !a.inFlight && a.nextDueMs <= nowMs,
+    );
+    const enabled = await Promise.all(candidates.map(a => isHeartbeatEnabledForAgent(a.agentId)));
+    candidates.forEach((agent, i) => {
+      if (!enabled[i]) return;
+      this.wake.requestHeartbeatNow({ reason: 'interval', agentId: agent.agentId });
+    });
   }
 
   /** Schedule a one-shot kick at the earliest upcoming due time. */
@@ -209,7 +210,16 @@ class HeartbeatService {
     if (agent?.inFlight) return { status: 'skipped', reason: 'requests-in-flight' };
 
     const got = await acquireLock(agentId, nowMs, reason);
-    if (!got) return { status: 'skipped', reason: 'requests-in-flight' };
+    if (!got) {
+      emitHeartbeatEvent({
+        agentId,
+        atMs: nowMs,
+        reason: classifyReason(reason),
+        status: 'skipped',
+        summary: 'requests-in-flight',
+      });
+      return { status: 'skipped', reason: 'requests-in-flight' };
+    }
 
     if (agent) agent.inFlight = true;
     try {
@@ -226,7 +236,7 @@ class HeartbeatService {
       this.state.deps.onEvent?.({
         agentId,
         atMs: nowMs,
-        reason: (reason as never) ?? 'interval',
+        reason: classifyReason(reason),
         status: result.status,
         chatId: result.chatId,
         durationMs: result.durationMs,

--- a/chrome-extension/src/background/heartbeat/service.ts
+++ b/chrome-extension/src/background/heartbeat/service.ts
@@ -13,7 +13,6 @@
 // delivery / channel dispatch (see `AgentsPanel` + channel bridges),
 // config persistence (see `config.ts`).
 
-import { chatDb, listAgents } from '@extension/storage';
 import { loadHeartbeatConfig } from './config';
 import { runHeartbeatOnce } from './service/run-once';
 import { createInitialState } from './service/state';
@@ -26,6 +25,7 @@ import {
   scheduleTick,
 } from './service/timer';
 import { createWakeQueue } from './service/wake';
+import { chatDb, listAgents } from '@extension/storage';
 import type { HeartbeatDeps, HeartbeatServiceState, AgentState } from './service/state';
 import type { HeartbeatRunResult } from './types';
 
@@ -39,19 +39,19 @@ const parseEveryToMs = (every: string | undefined): number => {
   const n = Number(m[1]);
   const unit = (m[2] ?? 'm').toLowerCase();
   const mult =
-    unit === 'ms' ? 1 :
-    unit === 's' ? 1_000 :
-    unit === 'm' ? 60_000 :
-    unit === 'h' ? 3_600_000 :
-    86_400_000;
+    unit === 'ms'
+      ? 1
+      : unit === 's'
+        ? 1_000
+        : unit === 'm'
+          ? 60_000
+          : unit === 'h'
+            ? 3_600_000
+            : 86_400_000;
   return Math.max(MIN_INTERVAL_MS, n * mult);
 };
 
-const acquireLock = async (
-  agentId: string,
-  nowMs: number,
-  reason?: string,
-): Promise<boolean> => {
+const acquireLock = async (agentId: string, nowMs: number, reason?: string): Promise<boolean> => {
   try {
     return await chatDb.transaction('rw', chatDb.heartbeatLocks, async () => {
       const existing = await chatDb.heartbeatLocks.get(agentId);
@@ -244,10 +244,4 @@ class HeartbeatService {
   }
 }
 
-export {
-  HeartbeatService,
-  LOCK_TTL_MS,
-  parseEveryToMs,
-  acquireLock,
-  releaseLock,
-};
+export { HeartbeatService, LOCK_TTL_MS, parseEveryToMs, acquireLock, releaseLock };

--- a/chrome-extension/src/background/heartbeat/service.ts
+++ b/chrome-extension/src/background/heartbeat/service.ts
@@ -1,0 +1,253 @@
+// ── HeartbeatService orchestrator ───────────────
+// Facade over state + wake queue + alarm timer + runHeartbeatOnce.
+//
+// Responsibilities:
+//  - Own the per-agent scheduler state (nextDueMs, intervalMs).
+//  - Translate chrome.alarms events into due-agent sweeps.
+//  - Serialize per-agent runs through a Dexie TTL lock (5 min) so the SW can
+//    be evicted mid-run without stranding the agent indefinitely.
+//  - Expose an imperative `requestHeartbeatNow` that routes through the
+//    coalescing wake queue.
+//
+// Not in scope: the actual heartbeat pipeline (see `service/run-once.ts`),
+// delivery / channel dispatch (see `AgentsPanel` + channel bridges),
+// config persistence (see `config.ts`).
+
+import { chatDb, listAgents } from '@extension/storage';
+import { loadHeartbeatConfig } from './config';
+import { runHeartbeatOnce } from './service/run-once';
+import { createInitialState } from './service/state';
+import {
+  HEARTBEAT_ALARM_NAME,
+  HEARTBEAT_KICK_ALARM_NAME,
+  clearAlarms,
+  isSchedulerAlarm,
+  scheduleKick,
+  scheduleTick,
+} from './service/timer';
+import { createWakeQueue } from './service/wake';
+import type { HeartbeatDeps, HeartbeatServiceState, AgentState } from './service/state';
+import type { HeartbeatRunResult } from './types';
+
+const LOCK_TTL_MS = 5 * 60 * 1000;
+const MIN_INTERVAL_MS = 60 * 1000; // 1 minute floor
+
+const parseEveryToMs = (every: string | undefined): number => {
+  if (!every) return 30 * 60 * 1000;
+  const m = /^\s*(\d+)\s*(ms|s|m|h|d)?\s*$/i.exec(every);
+  if (!m) return 30 * 60 * 1000;
+  const n = Number(m[1]);
+  const unit = (m[2] ?? 'm').toLowerCase();
+  const mult =
+    unit === 'ms' ? 1 :
+    unit === 's' ? 1_000 :
+    unit === 'm' ? 60_000 :
+    unit === 'h' ? 3_600_000 :
+    86_400_000;
+  return Math.max(MIN_INTERVAL_MS, n * mult);
+};
+
+const acquireLock = async (
+  agentId: string,
+  nowMs: number,
+  reason?: string,
+): Promise<boolean> => {
+  try {
+    return await chatDb.transaction('rw', chatDb.heartbeatLocks, async () => {
+      const existing = await chatDb.heartbeatLocks.get(agentId);
+      if (existing && existing.expiresAt > nowMs) return false;
+      await chatDb.heartbeatLocks.put({
+        agentId,
+        acquiredAt: nowMs,
+        expiresAt: nowMs + LOCK_TTL_MS,
+        reason,
+      });
+      return true;
+    });
+  } catch {
+    return false;
+  }
+};
+
+const releaseLock = async (agentId: string): Promise<void> => {
+  try {
+    await chatDb.heartbeatLocks.delete(agentId);
+  } catch {
+    /* best-effort */
+  }
+};
+
+class HeartbeatService {
+  private readonly state: HeartbeatServiceState;
+  private readonly wake = createWakeQueue();
+
+  constructor(deps: HeartbeatDeps) {
+    this.state = createInitialState(deps);
+    this.wake.setHandler(opts => this.runForAgent(opts.agentId, opts.reason));
+  }
+
+  /** Set up chrome.alarms + rehydrate wake queue. Idempotent. */
+  async start(): Promise<void> {
+    if (this.state.started) return;
+    this.state.started = true;
+    await this.refreshAgents();
+    scheduleTick();
+    await this.wake.hydrate();
+  }
+
+  /** Tear down; the SW may still be evicted after this. */
+  async stop(): Promise<void> {
+    this.state.started = false;
+    await clearAlarms();
+  }
+
+  /** Imperative run request (manual button, cron bridge, exec-event). */
+  requestHeartbeatNow(opts?: { reason?: string; agentId?: string; sessionKey?: string }): void {
+    this.wake.requestHeartbeatNow(opts);
+  }
+
+  /**
+   * Handle a chrome.alarms event. Swallows non-heartbeat alarms so the SW
+   * dispatcher can forward the same event to other subsystems.
+   */
+  async handleAlarm(alarm: chrome.alarms.Alarm): Promise<void> {
+    if (!isSchedulerAlarm(alarm.name)) return;
+    if (!this.state.started) return;
+    if (this.state.running) return;
+    this.state.running = true;
+    try {
+      await this.refreshAgents();
+      await this.runDueAgents();
+      this.rearmKick();
+    } finally {
+      this.state.running = false;
+    }
+  }
+
+  /** Test hook — returns a snapshot of per-agent runtime state. */
+  getAgentSnapshots(): AgentState[] {
+    return Array.from(this.state.agents.values()).map(a => ({ ...a }));
+  }
+
+  static isSchedulerAlarm(name: string): boolean {
+    return isSchedulerAlarm(name);
+  }
+
+  static readonly HEARTBEAT_ALARM_NAME = HEARTBEAT_ALARM_NAME;
+  static readonly HEARTBEAT_KICK_ALARM_NAME = HEARTBEAT_KICK_ALARM_NAME;
+
+  // ── internals ────────────────────────────────
+
+  private async refreshAgents(): Promise<void> {
+    const agents = await listAgents().catch(() => []);
+    const seen = new Set<string>();
+    const nowMs = this.state.deps.nowMs();
+    for (const agent of agents) {
+      seen.add(agent.id);
+      const config = await loadHeartbeatConfig(agent.id);
+      const intervalMs = parseEveryToMs(config.every);
+      const existing = this.state.agents.get(agent.id);
+      if (existing) {
+        existing.intervalMs = intervalMs;
+        // Only reset nextDueMs if unset (first refresh) to preserve drift.
+        if (!existing.nextDueMs) existing.nextDueMs = nowMs + intervalMs;
+      } else {
+        this.state.agents.set(agent.id, {
+          agentId: agent.id,
+          intervalMs,
+          nextDueMs: nowMs + intervalMs,
+          lastRunMs: 0,
+          inFlight: false,
+        });
+      }
+    }
+    // Drop agents that no longer exist.
+    for (const id of [...this.state.agents.keys()]) {
+      if (!seen.has(id)) this.state.agents.delete(id);
+    }
+  }
+
+  private async runDueAgents(): Promise<void> {
+    const nowMs = this.state.deps.nowMs();
+    for (const agent of this.state.agents.values()) {
+      if (agent.inFlight) continue;
+      if (agent.nextDueMs > nowMs) continue;
+      // Fire through the wake queue so concurrent manual requests coalesce.
+      this.wake.requestHeartbeatNow({
+        reason: 'interval',
+        agentId: agent.agentId,
+      });
+    }
+  }
+
+  /** Schedule a one-shot kick at the earliest upcoming due time. */
+  private rearmKick(): void {
+    const nowMs = this.state.deps.nowMs();
+    let earliest = Infinity;
+    for (const agent of this.state.agents.values()) {
+      if (agent.nextDueMs < earliest) earliest = agent.nextDueMs;
+    }
+    if (!Number.isFinite(earliest)) return;
+    // Only kick when the next due is before the next periodic tick (~60s).
+    if (earliest > nowMs + 55_000) return;
+    scheduleKick(earliest);
+  }
+
+  private async runForAgent(
+    agentIdMaybe: string | undefined,
+    reason: string | undefined,
+  ): Promise<HeartbeatRunResult> {
+    const log = this.state.deps.log;
+    const nowMs = this.state.deps.nowMs();
+    if (!agentIdMaybe) {
+      // Fan-out across due agents. Rare path — wake queue only queues single
+      // targets today, but we handle it defensively.
+      return { status: 'skipped', reason: 'no-agent' };
+    }
+    const agentId = agentIdMaybe;
+    const agent = this.state.agents.get(agentId);
+    if (agent?.inFlight) return { status: 'skipped', reason: 'requests-in-flight' };
+
+    const got = await acquireLock(agentId, nowMs, reason);
+    if (!got) return { status: 'skipped', reason: 'requests-in-flight' };
+
+    if (agent) agent.inFlight = true;
+    try {
+      const result = await runHeartbeatOnce({
+        agentId,
+        reason,
+        nowMs: this.state.deps.nowMs,
+        log,
+      });
+      if (agent) {
+        agent.lastRunMs = nowMs;
+        agent.nextDueMs = this.state.deps.nowMs() + agent.intervalMs;
+      }
+      this.state.deps.onEvent?.({
+        agentId,
+        atMs: nowMs,
+        reason: (reason as never) ?? 'interval',
+        status: result.status,
+        chatId: result.chatId,
+        durationMs: result.durationMs,
+        summary: result.reason,
+      });
+      return result;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error('heartbeat runForAgent crashed', { agentId, error: msg });
+      return { status: 'failed', reason: msg };
+    } finally {
+      if (agent) agent.inFlight = false;
+      await releaseLock(agentId);
+    }
+  }
+}
+
+export {
+  HeartbeatService,
+  LOCK_TTL_MS,
+  parseEveryToMs,
+  acquireLock,
+  releaseLock,
+};

--- a/chrome-extension/src/background/heartbeat/service/run-once.test.ts
+++ b/chrome-extension/src/background/heartbeat/service/run-once.test.ts
@@ -1,5 +1,9 @@
 // Unit tests for runHeartbeatOnce (R20 / 02.22, 02.25 sleep-catchup, 02.26 dedup).
 
+import { runHeartbeatOnce } from './run-once';
+import { loadHeartbeatConfig } from '../config';
+import { _resetHeartbeatListeners } from '../events';
+import { HEARTBEAT_TOKEN } from '../prompt';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the agent-setup module so we don't pull in pi-mono / providers.
@@ -24,12 +28,8 @@ vi.mock('../config', () => ({
     ackMaxChars: 300,
     target: 'last',
   })),
+  isHeartbeatEnabledForAgent: vi.fn(async () => true),
 }));
-
-import { runHeartbeatOnce } from './run-once';
-import { loadHeartbeatConfig } from '../config';
-import { _resetHeartbeatListeners } from '../events';
-import { HEARTBEAT_TOKEN } from '../prompt';
 
 const ts = Date.UTC(2026, 3, 1, 12, 0, 0);
 
@@ -70,6 +70,25 @@ describe('runHeartbeatOnce', () => {
     expect(res.status).toBe('skipped');
     expect(res.reason).toBe('disabled');
     expect(runHeadless).not.toHaveBeenCalled();
+  });
+
+  it('does not skip "disabled" when config.enabled is true', async () => {
+    // loadHeartbeatConfig resolves `enabled` via the two-rule resolver, so
+    // run-once simply trusts config.enabled without a separate resolver call.
+    setConfig({ enabled: true });
+    const runHeadless = vi.fn().mockResolvedValue({
+      status: 'ok',
+      chatId: 'chat-x',
+      responseText: HEARTBEAT_TOKEN,
+    });
+    const res = await runHeartbeatOnce({
+      agentId: 'a',
+      reason: 'manual',
+      nowMs: () => ts,
+      runHeadless: runHeadless as never,
+    });
+    expect(res.reason).not.toBe('disabled');
+    expect(runHeadless).toHaveBeenCalledTimes(1);
   });
 
   it('skips interval tick when HEARTBEAT.md is effectively empty', async () => {
@@ -162,26 +181,6 @@ describe('runHeartbeatOnce', () => {
     });
     expect(second.status).toBe('skipped');
     expect(second.reason).toBe('dedup');
-  });
-
-  it('skips when an active lock indicates in-flight', async () => {
-    const { chatDb } = await import('@extension/storage');
-    await chatDb.heartbeatLocks.put({
-      agentId: 'a',
-      acquiredAt: ts - 1_000,
-      expiresAt: ts + 60_000,
-    });
-
-    const runHeadless = vi.fn();
-    const res = await runHeartbeatOnce({
-      agentId: 'a',
-      reason: 'manual',
-      nowMs: () => ts,
-      runHeadless: runHeadless as never,
-    });
-    expect(res.status).toBe('skipped');
-    expect(res.reason).toBe('requests-in-flight');
-    expect(runHeadless).not.toHaveBeenCalled();
   });
 
   it('skips outside active hours', async () => {

--- a/chrome-extension/src/background/heartbeat/service/run-once.test.ts
+++ b/chrome-extension/src/background/heartbeat/service/run-once.test.ts
@@ -1,0 +1,204 @@
+// Unit tests for runHeartbeatOnce (R20 / 02.22, 02.25 sleep-catchup, 02.26 dedup).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the agent-setup module so we don't pull in pi-mono / providers.
+const mockModel = {
+  id: 'm1',
+  name: 'mock',
+  provider: 'custom' as const,
+  apiKey: 'x',
+  baseUrl: 'http://localhost',
+};
+
+vi.mock('../../agents/agent-setup', () => ({
+  runHeadlessLLM: vi.fn(),
+  resolveDefaultModel: vi.fn(async () => mockModel),
+  dbModelToChatModel: vi.fn((m: unknown) => m),
+}));
+
+vi.mock('../config', () => ({
+  loadHeartbeatConfig: vi.fn(async () => ({
+    enabled: true,
+    every: '30m',
+    ackMaxChars: 300,
+    target: 'last',
+  })),
+}));
+
+import { runHeartbeatOnce } from './run-once';
+import { loadHeartbeatConfig } from '../config';
+import { _resetHeartbeatListeners } from '../events';
+import { HEARTBEAT_TOKEN } from '../prompt';
+
+const ts = Date.UTC(2026, 3, 1, 12, 0, 0);
+
+const setConfig = (patch: Partial<Awaited<ReturnType<typeof loadHeartbeatConfig>>>) => {
+  vi.mocked(loadHeartbeatConfig).mockResolvedValueOnce({
+    enabled: true,
+    every: '30m',
+    ackMaxChars: 300,
+    target: 'last',
+    ...patch,
+  });
+};
+
+describe('runHeartbeatOnce', () => {
+  beforeEach(async () => {
+    const { chatDb } = await import('@extension/storage');
+    await chatDb.heartbeatState.clear();
+    await chatDb.heartbeatLocks.clear();
+    await chatDb.workspaceFiles.clear();
+    await chatDb.messages.clear();
+    await chatDb.chats.clear();
+  });
+
+  afterEach(() => {
+    _resetHeartbeatListeners();
+    vi.clearAllMocks();
+  });
+
+  it('skips when config is disabled', async () => {
+    setConfig({ enabled: false });
+    const runHeadless = vi.fn();
+    const res = await runHeartbeatOnce({
+      agentId: 'a',
+      reason: 'interval',
+      nowMs: () => ts,
+      runHeadless: runHeadless as never,
+    });
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('disabled');
+    expect(runHeadless).not.toHaveBeenCalled();
+  });
+
+  it('skips interval tick when HEARTBEAT.md is effectively empty', async () => {
+    const { chatDb } = await import('@extension/storage');
+    await chatDb.workspaceFiles.put({
+      id: 'wf-1',
+      agentId: 'a',
+      name: 'HEARTBEAT.md',
+      content: '# Heading\n\n- [ ]\n',
+      enabled: true,
+      owner: 'agent',
+      predefined: true,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    const runHeadless = vi.fn();
+    const res = await runHeartbeatOnce({
+      agentId: 'a',
+      reason: 'interval',
+      nowMs: () => ts,
+      runHeadless: runHeadless as never,
+    });
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('empty-heartbeat');
+    expect(runHeadless).not.toHaveBeenCalled();
+  });
+
+  it('runs on manual trigger even with empty HEARTBEAT.md', async () => {
+    const runHeadless = vi.fn().mockResolvedValue({
+      status: 'ok',
+      chatId: 'chat-1',
+      responseText: HEARTBEAT_TOKEN,
+    });
+    const res = await runHeartbeatOnce({
+      agentId: 'a',
+      reason: 'manual',
+      nowMs: () => ts,
+      runHeadless: runHeadless as never,
+    });
+    expect(runHeadless).toHaveBeenCalledTimes(1);
+    // HEARTBEAT_OK token alone → shouldSkip → 'ack'
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('ack');
+  });
+
+  it('persists lastHeartbeatText on delivered run', async () => {
+    const runHeadless = vi.fn().mockResolvedValue({
+      status: 'ok',
+      chatId: 'chat-2',
+      responseText: 'something the agent wants to say that is longer than the ack limit'.repeat(20),
+    });
+    const res = await runHeartbeatOnce({
+      agentId: 'a',
+      reason: 'manual',
+      nowMs: () => ts,
+      runHeadless: runHeadless as never,
+    });
+    expect(res.status).toBe('ran');
+
+    const { chatDb } = await import('@extension/storage');
+    const state = await chatDb.heartbeatState.get('a');
+    expect(state?.lastStatus).toBe('ran');
+    expect(state?.lastHeartbeatText).toBeTruthy();
+    expect(state?.lastHeartbeatSentAt).toBe(ts);
+  });
+
+  it('dedups identical non-ack text within 24h', async () => {
+    const longText = 'identical text '.repeat(40);
+
+    const runHeadless = vi.fn().mockResolvedValue({
+      status: 'ok',
+      chatId: 'chat-3',
+      responseText: longText,
+    });
+
+    const first = await runHeartbeatOnce({
+      agentId: 'a',
+      reason: 'manual',
+      nowMs: () => ts,
+      runHeadless: runHeadless as never,
+    });
+    expect(first.status).toBe('ran');
+
+    const second = await runHeartbeatOnce({
+      agentId: 'a',
+      reason: 'manual',
+      nowMs: () => ts + 60_000,
+      runHeadless: runHeadless as never,
+    });
+    expect(second.status).toBe('skipped');
+    expect(second.reason).toBe('dedup');
+  });
+
+  it('skips when an active lock indicates in-flight', async () => {
+    const { chatDb } = await import('@extension/storage');
+    await chatDb.heartbeatLocks.put({
+      agentId: 'a',
+      acquiredAt: ts - 1_000,
+      expiresAt: ts + 60_000,
+    });
+
+    const runHeadless = vi.fn();
+    const res = await runHeartbeatOnce({
+      agentId: 'a',
+      reason: 'manual',
+      nowMs: () => ts,
+      runHeadless: runHeadless as never,
+    });
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('requests-in-flight');
+    expect(runHeadless).not.toHaveBeenCalled();
+  });
+
+  it('skips outside active hours', async () => {
+    setConfig({
+      activeHours: { start: '09:00', end: '17:00', timezone: 'UTC' },
+    });
+    const runHeadless = vi.fn();
+    // 03:00 UTC is outside 09:00 - 17:00
+    const nightMs = Date.UTC(2026, 3, 1, 3, 0, 0);
+    const res = await runHeartbeatOnce({
+      agentId: 'a',
+      reason: 'interval',
+      nowMs: () => nightMs,
+      runHeadless: runHeadless as never,
+    });
+    expect(res.status).toBe('skipped');
+    expect(res.reason).toBe('inactive-hours');
+    expect(runHeadless).not.toHaveBeenCalled();
+  });
+});

--- a/chrome-extension/src/background/heartbeat/service/run-once.ts
+++ b/chrome-extension/src/background/heartbeat/service/run-once.ts
@@ -1,0 +1,338 @@
+// ── runHeartbeatOnce ────────────────────────────
+// Single-tick heartbeat execution for one agent. Mirrors OpenClaw's
+// `runHeartbeat` pipeline, collapsed for ChromeClaw:
+//
+//   1. config.enabled?                → skip 'disabled'
+//   2. inside activeHours?            → skip 'inactive-hours'
+//   3. agent already in-flight?       → skip 'requests-in-flight'
+//   4. HEARTBEAT.md empty + non-action trigger?  → skip 'empty-heartbeat'
+//   5. snapshot message id
+//   6. runHeadlessLLM with heartbeat prompt
+//   7. stripHeartbeatToken → ack? dedup hit? effectively empty?
+//        yes → pruneMessagesAbove(snapshot) + skip / skipped-ack
+//        no  → deliver via channel (best-effort) and persist state
+//
+// The implementation is intentionally self-contained: the caller (the service
+// orchestrator) owns lock acquisition, alarm scheduling, and retry.
+
+import { chatDb } from '@extension/storage';
+import { runHeadlessLLM, resolveDefaultModel, dbModelToChatModel } from '../../agents/agent-setup';
+import { customModelsStorage } from '@extension/storage';
+import { isWithinActiveHours } from '../active-hours';
+import { loadHeartbeatConfig } from '../config';
+import { emitHeartbeatEvent } from '../events';
+import {
+  isHeartbeatContentEffectivelyEmpty,
+  resolveHeartbeatPrompt,
+  stripHeartbeatToken,
+  DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+} from '../prompt';
+import { classifyReason, isActionLikeReason } from '../reason';
+import { pruneMessagesAbove, snapshotMaxMessageId } from '../transcript-prune';
+import type { HeartbeatRunResult } from '../types';
+import type { HeartbeatLogger, RunOutcome } from './state';
+
+interface RunHeartbeatOnceOptions {
+  agentId: string;
+  reason?: string;
+  nowMs?: () => number;
+  log?: HeartbeatLogger;
+  /** Allows tests to force the chat id associated with the run. */
+  chatTitle?: string;
+  /** If set, `runHeadlessLLM` is replaced by this callable (tests). */
+  runHeadless?: typeof runHeadlessLLM;
+}
+
+const DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h
+
+const hashText = (s: string): string => {
+  // Lightweight 53-bit hash (DJB2 xor). Sufficient for dedup bucket keys.
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h) ^ s.charCodeAt(i);
+  return String(h >>> 0);
+};
+
+const isInFlight = async (agentId: string, nowMs: number): Promise<boolean> => {
+  try {
+    const lock = await chatDb.heartbeatLocks.get(agentId);
+    if (!lock) return false;
+    if (lock.expiresAt <= nowMs) return false;
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const loadHeartbeatMdContent = async (agentId: string): Promise<string | undefined> => {
+  try {
+    const files = await chatDb.workspaceFiles
+      .where('agentId')
+      .equals(agentId)
+      .toArray();
+    const match = files.find(f => f.name === 'HEARTBEAT.md');
+    return match?.content;
+  } catch {
+    return undefined;
+  }
+};
+
+const resolveModelForAgent = async (modelHint?: string) => {
+  let model = await resolveDefaultModel();
+  if (modelHint) {
+    const models = await customModelsStorage.get();
+    const override = models?.find(m => m.modelId === modelHint || m.name === modelHint);
+    if (override) model = dbModelToChatModel(override);
+  }
+  return model;
+};
+
+const persistState = async (
+  agentId: string,
+  patch: Partial<{
+    lastRunAtMs: number;
+    lastStatus: 'ran' | 'skipped' | 'failed';
+    lastReason: string;
+    lastResultSummary: string;
+    lastHeartbeatText: string;
+    lastHeartbeatSentAt: number;
+    lastChatId: string;
+  }>,
+): Promise<void> => {
+  try {
+    const existing = await chatDb.heartbeatState.get(agentId);
+    await chatDb.heartbeatState.put({
+      agentId,
+      ...(existing ?? {}),
+      ...patch,
+    });
+  } catch {
+    /* storage unavailable */
+  }
+};
+
+const shouldSuppressByDedup = async (
+  agentId: string,
+  text: string,
+  nowMs: number,
+): Promise<boolean> => {
+  try {
+    const prior = await chatDb.heartbeatState.get(agentId);
+    if (!prior?.lastHeartbeatText || !prior.lastHeartbeatSentAt) return false;
+    if (nowMs - prior.lastHeartbeatSentAt > DEDUP_WINDOW_MS) return false;
+    return hashText(prior.lastHeartbeatText) === hashText(text);
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Execute one heartbeat tick for the given agent. Safe to call concurrently
+ * across agents; the caller must serialize per-agent calls via the Dexie lock.
+ */
+const runHeartbeatOnce = async (
+  opts: RunHeartbeatOnceOptions,
+): Promise<HeartbeatRunResult> => {
+  const { agentId } = opts;
+  const nowMs = opts.nowMs ?? (() => Date.now());
+  const log = opts.log;
+  const runHeadless = opts.runHeadless ?? runHeadlessLLM;
+  const reasonRaw = opts.reason ?? 'interval';
+  const reason = classifyReason(reasonRaw);
+  const startedAt = nowMs();
+
+  const finishSkip = async (skipReason: string): Promise<RunOutcome> => {
+    log?.debug?.('heartbeat skipped', { agentId, skipReason, reason });
+    await persistState(agentId, {
+      lastRunAtMs: startedAt,
+      lastStatus: 'skipped',
+      lastReason: skipReason,
+    });
+    emitHeartbeatEvent({
+      agentId,
+      atMs: startedAt,
+      reason,
+      status: 'skipped',
+      summary: skipReason,
+    });
+    return { status: 'skipped', reason: skipReason };
+  };
+
+  // 1. enabled?
+  const config = await loadHeartbeatConfig(agentId);
+  if (!config.enabled) return finishSkip('disabled');
+
+  // 2. active hours?
+  if (config.activeHours && !isWithinActiveHours(config.activeHours, startedAt)) {
+    return finishSkip('inactive-hours');
+  }
+
+  // 3. in-flight?
+  if (await isInFlight(agentId, startedAt)) {
+    return finishSkip('requests-in-flight');
+  }
+
+  // 4. empty HEARTBEAT.md with non-action trigger?
+  const heartbeatMd = await loadHeartbeatMdContent(agentId);
+  if (!isActionLikeReason(reason) && isHeartbeatContentEffectivelyEmpty(heartbeatMd)) {
+    return finishSkip('empty-heartbeat');
+  }
+
+  // 5. Snapshot the transcript so skip-cases can prune additions.
+  //    Heartbeat starts its own chat — we snapshot after chat creation by
+  //    pruning against the known chatId returned from runHeadlessLLM.
+  emitHeartbeatEvent({ agentId, atMs: startedAt, reason, status: 'started' });
+
+  // 6. Build & run.
+  const model = await resolveModelForAgent(config.model);
+  if (!model) {
+    log?.warn?.('heartbeat failed: no model', { agentId });
+    await persistState(agentId, {
+      lastRunAtMs: startedAt,
+      lastStatus: 'failed',
+      lastReason: 'no-model',
+    });
+    emitHeartbeatEvent({
+      agentId,
+      atMs: startedAt,
+      reason,
+      status: 'failed',
+      error: 'no-model',
+    });
+    return { status: 'failed', reason: 'no-model' };
+  }
+
+  const prompt = resolveHeartbeatPrompt(config.prompt);
+  const chatTitle = opts.chatTitle ?? `Heartbeat: ${agentId}`;
+
+  let result: Awaited<ReturnType<typeof runHeadlessLLM>>;
+  try {
+    result = await runHeadless({
+      message: prompt,
+      chatTitle,
+      model,
+      source: 'heartbeat',
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log?.error?.('heartbeat runHeadlessLLM threw', { agentId, error: msg });
+    await persistState(agentId, {
+      lastRunAtMs: startedAt,
+      lastStatus: 'failed',
+      lastReason: 'exception',
+      lastResultSummary: msg,
+    });
+    emitHeartbeatEvent({
+      agentId,
+      atMs: startedAt,
+      reason,
+      status: 'failed',
+      error: msg,
+      durationMs: nowMs() - startedAt,
+    });
+    return { status: 'failed', reason: msg };
+  }
+
+  const chatId = result.chatId;
+
+  if (result.status === 'error') {
+    const err = result.error ?? 'unknown-error';
+    await persistState(agentId, {
+      lastRunAtMs: startedAt,
+      lastStatus: 'failed',
+      lastReason: err,
+      lastChatId: chatId,
+    });
+    emitHeartbeatEvent({
+      agentId,
+      atMs: startedAt,
+      reason,
+      status: 'failed',
+      error: err,
+      chatId,
+      durationMs: nowMs() - startedAt,
+    });
+    return { status: 'failed', reason: err, chatId };
+  }
+
+  // 7. Strip HEARTBEAT_OK + dedup.
+  const stripped = stripHeartbeatToken(result.responseText, {
+    mode: 'heartbeat',
+    maxAckChars: config.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  });
+
+  const shouldPrune = stripped.shouldSkip || !stripped.text;
+  if (shouldPrune) {
+    // Snapshot was "chat before run"; since we created the chat fresh,
+    // null snapshot prunes everything, giving us a no-op transcript.
+    if (chatId) {
+      await pruneMessagesAbove(chatId, null).catch(() => 0);
+    }
+    await persistState(agentId, {
+      lastRunAtMs: startedAt,
+      lastStatus: 'skipped',
+      lastReason: 'ack',
+      lastChatId: chatId,
+    });
+    emitHeartbeatEvent({
+      agentId,
+      atMs: startedAt,
+      reason,
+      status: 'skipped',
+      summary: 'ack',
+      chatId,
+      durationMs: nowMs() - startedAt,
+    });
+    return { status: 'skipped', reason: 'ack', chatId };
+  }
+
+  // Dedup: identical non-ack text within 24h → prune and skip.
+  if (await shouldSuppressByDedup(agentId, stripped.text, startedAt)) {
+    if (chatId) {
+      await pruneMessagesAbove(chatId, null).catch(() => 0);
+    }
+    await persistState(agentId, {
+      lastRunAtMs: startedAt,
+      lastStatus: 'skipped',
+      lastReason: 'dedup',
+      lastChatId: chatId,
+    });
+    emitHeartbeatEvent({
+      agentId,
+      atMs: startedAt,
+      reason,
+      status: 'skipped',
+      summary: 'dedup',
+      chatId,
+      durationMs: nowMs() - startedAt,
+    });
+    return { status: 'skipped', reason: 'dedup', chatId };
+  }
+
+  // Deliver: persist state, emit `ran` event. Channel dispatch is handled
+  // by a listener (AgentsPanel UI, channels bridge). Keeping delivery out of
+  // this module avoids a hard dep on the channels registry and lets the UI
+  // be the single source of truth for alert rendering.
+  await persistState(agentId, {
+    lastRunAtMs: startedAt,
+    lastStatus: 'ran',
+    lastReason: String(reason),
+    lastResultSummary: stripped.text.slice(0, 200),
+    lastHeartbeatText: stripped.text,
+    lastHeartbeatSentAt: startedAt,
+    lastChatId: chatId,
+  });
+  const durationMs = nowMs() - startedAt;
+  emitHeartbeatEvent({
+    agentId,
+    atMs: startedAt,
+    reason,
+    status: 'ran',
+    chatId,
+    durationMs,
+    summary: stripped.text.slice(0, 200),
+  });
+  return { status: 'ran', chatId, durationMs };
+};
+
+export { runHeartbeatOnce, DEDUP_WINDOW_MS, hashText };
+export type { RunHeartbeatOnceOptions };

--- a/chrome-extension/src/background/heartbeat/service/run-once.ts
+++ b/chrome-extension/src/background/heartbeat/service/run-once.ts
@@ -15,9 +15,7 @@
 // The implementation is intentionally self-contained: the caller (the service
 // orchestrator) owns lock acquisition, alarm scheduling, and retry.
 
-import { chatDb } from '@extension/storage';
 import { runHeadlessLLM, resolveDefaultModel, dbModelToChatModel } from '../../agents/agent-setup';
-import { customModelsStorage } from '@extension/storage';
 import { isWithinActiveHours } from '../active-hours';
 import { loadHeartbeatConfig } from '../config';
 import { emitHeartbeatEvent } from '../events';
@@ -28,7 +26,8 @@ import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
 } from '../prompt';
 import { classifyReason, isActionLikeReason } from '../reason';
-import { pruneMessagesAbove, snapshotMaxMessageId } from '../transcript-prune';
+import { pruneMessagesAbove } from '../transcript-prune';
+import { customModelsStorage, chatDb } from '@extension/storage';
 import type { HeartbeatRunResult } from '../types';
 import type { HeartbeatLogger, RunOutcome } from './state';
 
@@ -65,10 +64,7 @@ const isInFlight = async (agentId: string, nowMs: number): Promise<boolean> => {
 
 const loadHeartbeatMdContent = async (agentId: string): Promise<string | undefined> => {
   try {
-    const files = await chatDb.workspaceFiles
-      .where('agentId')
-      .equals(agentId)
-      .toArray();
+    const files = await chatDb.workspaceFiles.where('agentId').equals(agentId).toArray();
     const match = files.find(f => f.name === 'HEARTBEAT.md');
     return match?.content;
   } catch {
@@ -129,9 +125,7 @@ const shouldSuppressByDedup = async (
  * Execute one heartbeat tick for the given agent. Safe to call concurrently
  * across agents; the caller must serialize per-agent calls via the Dexie lock.
  */
-const runHeartbeatOnce = async (
-  opts: RunHeartbeatOnceOptions,
-): Promise<HeartbeatRunResult> => {
+const runHeartbeatOnce = async (opts: RunHeartbeatOnceOptions): Promise<HeartbeatRunResult> => {
   const { agentId } = opts;
   const nowMs = opts.nowMs ?? (() => Date.now());
   const log = opts.log;

--- a/chrome-extension/src/background/heartbeat/service/run-once.ts
+++ b/chrome-extension/src/background/heartbeat/service/run-once.ts
@@ -16,6 +16,8 @@
 // orchestrator) owns lock acquisition, alarm scheduling, and retry.
 
 import { runHeadlessLLM, resolveDefaultModel, dbModelToChatModel } from '../../agents/agent-setup';
+import { getChannelConfigs } from '../../channels/config';
+import { getChannelAdapter } from '../../channels/registry';
 import { isWithinActiveHours } from '../active-hours';
 import { loadHeartbeatConfig } from '../config';
 import { emitHeartbeatEvent } from '../events';
@@ -28,7 +30,7 @@ import {
 import { classifyReason, isActionLikeReason } from '../reason';
 import { pruneMessagesAbove } from '../transcript-prune';
 import { customModelsStorage, chatDb } from '@extension/storage';
-import type { HeartbeatRunResult } from '../types';
+import type { HeartbeatConfig, HeartbeatRunResult } from '../types';
 import type { HeartbeatLogger, RunOutcome } from './state';
 
 interface RunHeartbeatOnceOptions {
@@ -43,24 +45,6 @@ interface RunHeartbeatOnceOptions {
 }
 
 const DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h
-
-const hashText = (s: string): string => {
-  // Lightweight 53-bit hash (DJB2 xor). Sufficient for dedup bucket keys.
-  let h = 5381;
-  for (let i = 0; i < s.length; i++) h = ((h << 5) + h) ^ s.charCodeAt(i);
-  return String(h >>> 0);
-};
-
-const isInFlight = async (agentId: string, nowMs: number): Promise<boolean> => {
-  try {
-    const lock = await chatDb.heartbeatLocks.get(agentId);
-    if (!lock) return false;
-    if (lock.expiresAt <= nowMs) return false;
-    return true;
-  } catch {
-    return false;
-  }
-};
 
 const loadHeartbeatMdContent = async (agentId: string): Promise<string | undefined> => {
   try {
@@ -115,10 +99,70 @@ const shouldSuppressByDedup = async (
     const prior = await chatDb.heartbeatState.get(agentId);
     if (!prior?.lastHeartbeatText || !prior.lastHeartbeatSentAt) return false;
     if (nowMs - prior.lastHeartbeatSentAt > DEDUP_WINDOW_MS) return false;
-    return hashText(prior.lastHeartbeatText) === hashText(text);
+    return prior.lastHeartbeatText === text;
   } catch {
     return false;
   }
+};
+
+/**
+ * Deliver heartbeat text to a channel (Telegram, WhatsApp, etc.).
+ * Follows the same pattern as cron executor's `deliverResult`.
+ */
+const deliverToChannel = async (
+  config: HeartbeatConfig,
+  text: string,
+  log?: HeartbeatLogger,
+): Promise<void> => {
+  // config.target: 'last' = first active channel, 'none' = skip, string = channel id
+  const target = config.target ?? 'last';
+  if (target === 'none') return;
+
+  let channelId: string | undefined;
+  let to: string | undefined;
+
+  if (target === 'last') {
+    // Auto-resolve: pick first active channel with allowed senders
+    const configs = await getChannelConfigs();
+    const active = configs.find(
+      c => c.enabled && c.status !== 'idle' && c.allowedSenderIds.length > 0,
+    );
+    if (!active) return; // No active channel — silently skip
+    channelId = active.channelId;
+    to = config.to ?? active.allowedSenderIds[0];
+  } else {
+    channelId = target;
+    to = config.to;
+  }
+
+  if (!channelId || !to) return;
+
+  const adapter = await getChannelAdapter(channelId);
+  if (!adapter) {
+    log?.warn?.('heartbeat channel delivery: no adapter', { channelId });
+    return;
+  }
+
+  const msg =
+    text.length > adapter.maxMessageLength ? text.slice(0, adapter.maxMessageLength) : text;
+
+  const result = await adapter.sendMessage({ to, text: msg, parseMode: 'markdown' });
+  if (result.ok) {
+    log?.info?.('heartbeat delivered to channel', { channelId, to, messageId: result.messageId });
+  } else {
+    log?.warn?.('heartbeat channel delivery failed', { channelId, error: result.error });
+  }
+};
+
+/** Notify the chat UI that a heartbeat produced a message worth showing. */
+const notifyChatUI = (chatId: string, agentId: string): void => {
+  chrome.runtime
+    .sendMessage({
+      type: 'HEARTBEAT_CHAT_DELIVERED',
+      chatId,
+      agentId,
+    })
+    .catch(() => {}); // No listeners is fine
 };
 
 /**
@@ -151,7 +195,8 @@ const runHeartbeatOnce = async (opts: RunHeartbeatOnceOptions): Promise<Heartbea
     return { status: 'skipped', reason: skipReason };
   };
 
-  // 1. enabled?
+  // 1. enabled? — consult the resolver so the default agent runs out of the
+  //    box and explicit opt-in configs flip semantics correctly.
   const config = await loadHeartbeatConfig(agentId);
   if (!config.enabled) return finishSkip('disabled');
 
@@ -160,23 +205,16 @@ const runHeartbeatOnce = async (opts: RunHeartbeatOnceOptions): Promise<Heartbea
     return finishSkip('inactive-hours');
   }
 
-  // 3. in-flight?
-  if (await isInFlight(agentId, startedAt)) {
-    return finishSkip('requests-in-flight');
-  }
-
-  // 4. empty HEARTBEAT.md with non-action trigger?
+  // 3. empty HEARTBEAT.md with non-action trigger?
   const heartbeatMd = await loadHeartbeatMdContent(agentId);
   if (!isActionLikeReason(reason) && isHeartbeatContentEffectivelyEmpty(heartbeatMd)) {
     return finishSkip('empty-heartbeat');
   }
 
-  // 5. Snapshot the transcript so skip-cases can prune additions.
-  //    Heartbeat starts its own chat — we snapshot after chat creation by
-  //    pruning against the known chatId returned from runHeadlessLLM.
+  // 4. Emit started event.
   emitHeartbeatEvent({ agentId, atMs: startedAt, reason, status: 'started' });
 
-  // 6. Build & run.
+  // 5. Build & run.
   const model = await resolveModelForAgent(config.model);
   if (!model) {
     log?.warn?.('heartbeat failed: no model', { agentId });
@@ -197,6 +235,14 @@ const runHeartbeatOnce = async (opts: RunHeartbeatOnceOptions): Promise<Heartbea
 
   const prompt = resolveHeartbeatPrompt(config.prompt);
   const chatTitle = opts.chatTitle ?? `Heartbeat: ${agentId}`;
+
+  log?.info?.('heartbeat request', {
+    agentId,
+    reason,
+    model: model.id,
+    prompt,
+    heartbeatMd: heartbeatMd?.slice(0, 500),
+  });
 
   let result: Awaited<ReturnType<typeof runHeadlessLLM>>;
   try {
@@ -227,6 +273,14 @@ const runHeartbeatOnce = async (opts: RunHeartbeatOnceOptions): Promise<Heartbea
   }
 
   const chatId = result.chatId;
+
+  log?.info?.('heartbeat response', {
+    agentId,
+    chatId,
+    status: result.status,
+    responseText: result.responseText?.slice(0, 1000),
+    durationMs: nowMs() - startedAt,
+  });
 
   if (result.status === 'error') {
     const err = result.error ?? 'unknown-error';
@@ -302,10 +356,7 @@ const runHeartbeatOnce = async (opts: RunHeartbeatOnceOptions): Promise<Heartbea
     return { status: 'skipped', reason: 'dedup', chatId };
   }
 
-  // Deliver: persist state, emit `ran` event. Channel dispatch is handled
-  // by a listener (AgentsPanel UI, channels bridge). Keeping delivery out of
-  // this module avoids a hard dep on the channels registry and lets the UI
-  // be the single source of truth for alert rendering.
+  // Deliver: persist state, notify chat UI, and send to channel.
   await persistState(agentId, {
     lastRunAtMs: startedAt,
     lastStatus: 'ran',
@@ -316,6 +367,22 @@ const runHeartbeatOnce = async (opts: RunHeartbeatOnceOptions): Promise<Heartbea
     lastChatId: chatId,
   });
   const durationMs = nowMs() - startedAt;
+
+  // Notify chat UI so it can show the heartbeat conversation
+  if (chatId) {
+    notifyChatUI(chatId, agentId);
+  }
+
+  // Deliver to channel (Telegram/WhatsApp) — best-effort, don't fail the run
+  try {
+    await deliverToChannel(config, stripped.text, log);
+  } catch (err) {
+    log?.warn?.('heartbeat channel delivery error', {
+      agentId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
   emitHeartbeatEvent({
     agentId,
     atMs: startedAt,
@@ -328,5 +395,5 @@ const runHeartbeatOnce = async (opts: RunHeartbeatOnceOptions): Promise<Heartbea
   return { status: 'ran', chatId, durationMs };
 };
 
-export { runHeartbeatOnce, DEDUP_WINDOW_MS, hashText };
+export { runHeartbeatOnce, DEDUP_WINDOW_MS };
 export type { RunHeartbeatOnceOptions };

--- a/chrome-extension/src/background/heartbeat/service/state.ts
+++ b/chrome-extension/src/background/heartbeat/service/state.ts
@@ -1,0 +1,62 @@
+// ── Heartbeat service state + deps ──────────────
+// In-memory structures owned by the singleton HeartbeatService.
+
+import type { HeartbeatEvent, HeartbeatRunResult } from '../types';
+
+/** Output of a single `runHeartbeatOnce` invocation. */
+type RunOutcome = HeartbeatRunResult;
+
+interface HeartbeatLogger {
+  debug: (message: string, data?: unknown) => void;
+  info: (message: string, data?: unknown) => void;
+  warn: (message: string, data?: unknown) => void;
+  error: (message: string, data?: unknown) => void;
+  trace?: (message: string, data?: unknown) => void;
+}
+
+/** Per-agent runtime state kept across ticks (durable data lives in Dexie). */
+interface AgentState {
+  agentId: string;
+  /** Next scheduled tick wall-clock ms (alarm-driven). */
+  nextDueMs: number;
+  /** Last successful run (either `ran` or `skipped`). */
+  lastRunMs: number;
+  /** Millisecond interval derived from HeartbeatConfig.every. */
+  intervalMs: number;
+  /** True while `runHeartbeatOnce` is executing for this agent. */
+  inFlight: boolean;
+}
+
+interface HeartbeatDeps {
+  nowMs?: () => number;
+  log: HeartbeatLogger;
+  onEvent?: (event: HeartbeatEvent) => void;
+}
+
+interface HeartbeatDepsInternal extends HeartbeatDeps {
+  nowMs: () => number;
+}
+
+interface HeartbeatServiceState {
+  deps: HeartbeatDepsInternal;
+  agents: Map<string, AgentState>;
+  started: boolean;
+  running: boolean;
+}
+
+const createInitialState = (deps: HeartbeatDeps): HeartbeatServiceState => ({
+  deps: { ...deps, nowMs: deps.nowMs ?? (() => Date.now()) },
+  agents: new Map(),
+  started: false,
+  running: false,
+});
+
+export { createInitialState };
+export type {
+  RunOutcome,
+  HeartbeatLogger,
+  AgentState,
+  HeartbeatDeps,
+  HeartbeatDepsInternal,
+  HeartbeatServiceState,
+};

--- a/chrome-extension/src/background/heartbeat/service/timer.ts
+++ b/chrome-extension/src/background/heartbeat/service/timer.ts
@@ -1,0 +1,70 @@
+// ── Alarm timer integration ─────────────────────
+// Two `chrome.alarms` are owned by the heartbeat subsystem:
+//
+//  - `heartbeat-tick`: a periodic (1-minute) alarm that wakes the service
+//    worker so the per-agent scheduler can decide whether any agent is due.
+//    This is the steady-state driver; it survives SW eviction because MV3
+//    re-creates the SW when an alarm fires.
+//
+//  - `heartbeat-kick`: a one-shot alarm fired at a specific `when` timestamp
+//    to catch a due time that would otherwise fall inside a 1-minute gap
+//    (e.g. agent due in 30s). Coexists with the periodic tick.
+//
+// Keeping both names exported lets the SW-level `onAlarm` dispatcher filter
+// heartbeat alarms out of the cron dispatcher with a cheap string compare.
+
+const HEARTBEAT_ALARM_NAME = 'heartbeat-tick';
+const HEARTBEAT_KICK_ALARM_NAME = 'heartbeat-kick';
+
+/** True when the alarm is owned by the heartbeat subsystem. */
+const isSchedulerAlarm = (name: string | undefined | null): boolean =>
+  name === HEARTBEAT_ALARM_NAME || name === HEARTBEAT_KICK_ALARM_NAME;
+
+/**
+ * Arm the periodic tick. Idempotent — Chrome replaces any existing alarm with
+ * the same name. Using `periodInMinutes: 1` is the minimum Chrome honours
+ * reliably (30s is technically accepted but drifts under load).
+ */
+const scheduleTick = (): void => {
+  try {
+    chrome.alarms.create(HEARTBEAT_ALARM_NAME, {
+      periodInMinutes: 1,
+      when: Date.now() + 60_000,
+    });
+  } catch {
+    /* alarms unavailable (tests / non-SW ctx) */
+  }
+};
+
+/**
+ * Schedule a one-shot kick at `whenMs`. Chrome enforces a floor of ~30s for
+ * `when`; clamp aggressively so callers never miss an event by passing in
+ * a past / near-past timestamp.
+ */
+const scheduleKick = (whenMs: number): void => {
+  try {
+    const when = Math.max(whenMs, Date.now() + 1_000);
+    chrome.alarms.create(HEARTBEAT_KICK_ALARM_NAME, { when });
+  } catch {
+    /* alarms unavailable */
+  }
+};
+
+/** Clear both alarms; used on `stop()`. */
+const clearAlarms = async (): Promise<void> => {
+  try {
+    await chrome.alarms.clear(HEARTBEAT_ALARM_NAME);
+    await chrome.alarms.clear(HEARTBEAT_KICK_ALARM_NAME);
+  } catch {
+    /* best-effort */
+  }
+};
+
+export {
+  HEARTBEAT_ALARM_NAME,
+  HEARTBEAT_KICK_ALARM_NAME,
+  isSchedulerAlarm,
+  scheduleTick,
+  scheduleKick,
+  clearAlarms,
+};

--- a/chrome-extension/src/background/heartbeat/service/wake.test.ts
+++ b/chrome-extension/src/background/heartbeat/service/wake.test.ts
@@ -1,7 +1,7 @@
 // Unit tests for the coalescing wake queue (R20 / 02.21).
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createWakeQueue, DEFAULT_RETRY_MS } from './wake';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { HeartbeatRunResult } from '../types';
 
 // Minimal chrome.storage.session stub so persist()/hydrate() don't throw.
@@ -122,6 +122,34 @@ describe('wakeQueue', () => {
     await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_MS + 50);
     expect(handler).toHaveBeenCalledTimes(2);
     expect(handler.mock.calls[1][0]).toMatchObject({ reason: 'retry', agentId: 'a' });
+  });
+
+  it('drops stale wakes enqueued during a successful run', async () => {
+    const q = createWakeQueue();
+    let resolveRun!: (v: HeartbeatRunResult) => void;
+    const handler = vi
+      .fn<(opts: unknown) => Promise<HeartbeatRunResult>>()
+      .mockImplementationOnce(
+        () => new Promise<HeartbeatRunResult>(r => { resolveRun = r; }),
+      )
+      .mockResolvedValue({ status: 'ran' });
+    q.setHandler(handler);
+
+    // First click
+    q.requestHeartbeatNow({ reason: 'manual', agentId: 'a' });
+    await vi.advanceTimersByTimeAsync(300);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Second and third clicks arrive while run #1 is in-flight
+    q.requestHeartbeatNow({ reason: 'manual', agentId: 'a' });
+    q.requestHeartbeatNow({ reason: 'manual', agentId: 'a' });
+
+    // Run #1 completes — pending wakes for agent 'a' should be dropped
+    resolveRun({ status: 'ran' });
+    await vi.advanceTimersByTimeAsync(500);
+
+    // Handler should NOT have been called a second time
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 
   it('reports hasPendingWake() truthfully through the lifecycle', async () => {

--- a/chrome-extension/src/background/heartbeat/service/wake.test.ts
+++ b/chrome-extension/src/background/heartbeat/service/wake.test.ts
@@ -1,0 +1,142 @@
+// Unit tests for the coalescing wake queue (R20 / 02.21).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWakeQueue, DEFAULT_RETRY_MS } from './wake';
+import type { HeartbeatRunResult } from '../types';
+
+// Minimal chrome.storage.session stub so persist()/hydrate() don't throw.
+const installChromeStub = (): void => {
+  const store: Record<string, unknown> = {};
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    storage: {
+      session: {
+        get: async (key: string) => ({ [key]: store[key] }),
+        set: async (rec: Record<string, unknown>) => {
+          Object.assign(store, rec);
+        },
+        remove: async (key: string) => {
+          delete store[key];
+        },
+      },
+    },
+  };
+};
+
+const flush = async (): Promise<void> => {
+  // Let any queued microtasks and timers settle.
+  await vi.runAllTimersAsync();
+};
+
+describe('wakeQueue', () => {
+  beforeEach(() => {
+    installChromeStub();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces multiple wakes for the same target into a single invocation', async () => {
+    const q = createWakeQueue();
+    const handler = vi.fn<(opts: unknown) => Promise<HeartbeatRunResult>>().mockResolvedValue({
+      status: 'ran',
+    });
+    q.setHandler(handler);
+
+    q.requestHeartbeatNow({ reason: 'interval', agentId: 'a' });
+    q.requestHeartbeatNow({ reason: 'interval', agentId: 'a' });
+    q.requestHeartbeatNow({ reason: 'interval', agentId: 'a' });
+
+    await flush();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toMatchObject({ reason: 'interval', agentId: 'a' });
+  });
+
+  it('higher-priority reason (manual) wins over interval for same target', async () => {
+    const q = createWakeQueue();
+    const handler = vi.fn<(opts: unknown) => Promise<HeartbeatRunResult>>().mockResolvedValue({
+      status: 'ran',
+    });
+    q.setHandler(handler);
+
+    q.requestHeartbeatNow({ reason: 'interval', agentId: 'a' });
+    q.requestHeartbeatNow({ reason: 'manual', agentId: 'a' });
+
+    await flush();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toMatchObject({ reason: 'manual' });
+  });
+
+  it('retry reason does NOT displace a pending interval wake', async () => {
+    const q = createWakeQueue();
+    const handler = vi.fn<(opts: unknown) => Promise<HeartbeatRunResult>>().mockResolvedValue({
+      status: 'ran',
+    });
+    q.setHandler(handler);
+
+    q.requestHeartbeatNow({ reason: 'interval', agentId: 'a' });
+    q.requestHeartbeatNow({ reason: 'retry', agentId: 'a' });
+
+    await flush();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toMatchObject({ reason: 'interval' });
+  });
+
+  it('distinct agents are NOT coalesced', async () => {
+    const q = createWakeQueue();
+    const handler = vi.fn<(opts: unknown) => Promise<HeartbeatRunResult>>().mockResolvedValue({
+      status: 'ran',
+    });
+    q.setHandler(handler);
+
+    q.requestHeartbeatNow({ reason: 'interval', agentId: 'a' });
+    q.requestHeartbeatNow({ reason: 'interval', agentId: 'b' });
+
+    await flush();
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    const agentIds = handler.mock.calls.map(c => (c[0] as { agentId: string }).agentId).sort();
+    expect(agentIds).toEqual(['a', 'b']);
+  });
+
+  it('requeues with retry cooldown on requests-in-flight skip', async () => {
+    const q = createWakeQueue();
+    const handler = vi
+      .fn<(opts: unknown) => Promise<HeartbeatRunResult>>()
+      .mockResolvedValueOnce({ status: 'skipped', reason: 'requests-in-flight' })
+      .mockResolvedValueOnce({ status: 'ran' });
+    q.setHandler(handler);
+
+    q.requestHeartbeatNow({ reason: 'manual', agentId: 'a' });
+
+    // Initial coalesce fires the first call.
+    await vi.advanceTimersByTimeAsync(300);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(q.hasPendingWake()).toBe(true);
+
+    // Retry cooldown must wait the full backoff.
+    await vi.advanceTimersByTimeAsync(DEFAULT_RETRY_MS + 50);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[1][0]).toMatchObject({ reason: 'retry', agentId: 'a' });
+  });
+
+  it('reports hasPendingWake() truthfully through the lifecycle', async () => {
+    const q = createWakeQueue();
+    const handler = vi.fn<(opts: unknown) => Promise<HeartbeatRunResult>>().mockResolvedValue({
+      status: 'ran',
+    });
+    q.setHandler(handler);
+
+    expect(q.hasPendingWake()).toBe(false);
+    q.requestHeartbeatNow({ reason: 'interval', agentId: 'a' });
+    expect(q.hasPendingWake()).toBe(true);
+
+    await flush();
+
+    expect(q.hasPendingWake()).toBe(false);
+  });
+});

--- a/chrome-extension/src/background/heartbeat/service/wake.ts
+++ b/chrome-extension/src/background/heartbeat/service/wake.ts
@@ -1,0 +1,281 @@
+// ── Coalescing wake queue ───────────────────────
+// Ported from OpenClaw's `heartbeat-wake.ts`, adapted for MV3 service workers:
+// - The in-memory timer still drives fast coalescing (tens to hundreds of ms).
+// - Pending wake intents are mirrored to `chrome.storage.session` so they
+//   survive short SW evictions. A subsequent tick rehydrates and drains them.
+//
+// Priority ordering for merging wakes that target the same (agentId,
+// sessionKey) tuple: RETRY < INTERVAL < DEFAULT < ACTION. A higher-priority
+// request wins; equal priority keeps the most recent request.
+
+import { classifyReason, isActionLikeReason } from '../reason';
+import type { HeartbeatRunResult } from '../types';
+
+interface WakeOptions {
+  reason?: string;
+  agentId?: string;
+  sessionKey?: string;
+}
+
+type WakeHandler = (opts: WakeOptions) => Promise<HeartbeatRunResult>;
+
+type WakeTimerKind = 'normal' | 'retry';
+
+interface PendingWake {
+  reason: string;
+  priority: number;
+  requestedAt: number;
+  agentId?: string;
+  sessionKey?: string;
+}
+
+const DEFAULT_COALESCE_MS = 250;
+const DEFAULT_RETRY_MS = 1_000;
+const SESSION_STORAGE_KEY = 'heartbeat.pendingWakes';
+
+const REASON_PRIORITY = {
+  RETRY: 0,
+  INTERVAL: 1,
+  DEFAULT: 2,
+  ACTION: 3,
+} as const;
+
+const normalizeReason = (reason?: string): string => {
+  const trimmed = typeof reason === 'string' ? reason.trim() : '';
+  return trimmed || 'interval';
+};
+
+const normalizeTarget = (value?: string): string | undefined => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed || undefined;
+};
+
+const targetKey = (agentId?: string, sessionKey?: string): string =>
+  `${agentId ?? ''}::${sessionKey ?? ''}`;
+
+const resolvePriority = (reason: string): number => {
+  const kind = classifyReason(reason);
+  if (kind === 'retry') return REASON_PRIORITY.RETRY;
+  if (kind === 'interval') return REASON_PRIORITY.INTERVAL;
+  if (isActionLikeReason(kind)) return REASON_PRIORITY.ACTION;
+  return REASON_PRIORITY.DEFAULT;
+};
+
+interface WakeQueue {
+  /** Queue a wake; returns once the pending entry has been persisted. */
+  requestHeartbeatNow: (opts?: WakeOptions & { coalesceMs?: number }) => void;
+  /** Install (or replace) the wake handler. Returns a disposer. */
+  setHandler: (next: WakeHandler | null) => () => void;
+  hasPendingWake: () => boolean;
+  /** Re-hydrate pending wakes from session storage; call on SW startup. */
+  hydrate: () => Promise<void>;
+  /** Test helper. */
+  _reset: () => void;
+}
+
+const createWakeQueue = (): WakeQueue => {
+  const pending = new Map<string, PendingWake>();
+  let handler: WakeHandler | null = null;
+  let handlerGeneration = 0;
+  let scheduled = false;
+  let running = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let timerDueAt: number | null = null;
+  let timerKind: WakeTimerKind | null = null;
+
+  const persist = (): void => {
+    try {
+      const snapshot = Array.from(pending.values());
+      if (snapshot.length === 0) {
+        void chrome.storage?.session?.remove?.(SESSION_STORAGE_KEY);
+        return;
+      }
+      void chrome.storage?.session?.set?.({ [SESSION_STORAGE_KEY]: snapshot });
+    } catch {
+      /* chrome.storage.session unavailable (tests / non-SW ctx) */
+    }
+  };
+
+  const enqueue = (params: {
+    reason?: string;
+    requestedAt?: number;
+    agentId?: string;
+    sessionKey?: string;
+  }): void => {
+    const requestedAt = params.requestedAt ?? Date.now();
+    const reason = normalizeReason(params.reason);
+    const agentId = normalizeTarget(params.agentId);
+    const sessionKey = normalizeTarget(params.sessionKey);
+    const key = targetKey(agentId, sessionKey);
+    const next: PendingWake = {
+      reason,
+      priority: resolvePriority(reason),
+      requestedAt,
+      agentId,
+      sessionKey,
+    };
+    const prev = pending.get(key);
+    if (!prev) {
+      pending.set(key, next);
+    } else if (next.priority > prev.priority) {
+      pending.set(key, next);
+    } else if (next.priority === prev.priority && next.requestedAt >= prev.requestedAt) {
+      pending.set(key, next);
+    }
+    persist();
+  };
+
+  const schedule = (coalesceMs: number, kind: WakeTimerKind = 'normal'): void => {
+    const delay = Number.isFinite(coalesceMs) ? Math.max(0, coalesceMs) : DEFAULT_COALESCE_MS;
+    const dueAt = Date.now() + delay;
+    if (timer) {
+      // Retry cooldown is sticky — do not collapse backoff.
+      if (timerKind === 'retry') return;
+      if (typeof timerDueAt === 'number' && timerDueAt <= dueAt) return;
+      clearTimeout(timer);
+      timer = null;
+      timerDueAt = null;
+      timerKind = null;
+    }
+    timerDueAt = dueAt;
+    timerKind = kind;
+    timer = setTimeout(() => {
+      void fire(delay, kind);
+    }, delay);
+  };
+
+  const fire = async (delay: number, kind: WakeTimerKind): Promise<void> => {
+    timer = null;
+    timerDueAt = null;
+    timerKind = null;
+    scheduled = false;
+
+    const active = handler;
+    if (!active) return;
+    if (running) {
+      scheduled = true;
+      schedule(delay, kind);
+      return;
+    }
+
+    const batch = Array.from(pending.values());
+    pending.clear();
+    persist();
+    running = true;
+    try {
+      for (const w of batch) {
+        const opts: WakeOptions = {
+          reason: w.reason,
+          ...(w.agentId ? { agentId: w.agentId } : {}),
+          ...(w.sessionKey ? { sessionKey: w.sessionKey } : {}),
+        };
+        const res = await active(opts);
+        if (res.status === 'skipped' && res.reason === 'requests-in-flight') {
+          enqueue({
+            reason: 'retry',
+            agentId: w.agentId,
+            sessionKey: w.sessionKey,
+          });
+          schedule(DEFAULT_RETRY_MS, 'retry');
+        }
+      }
+    } catch {
+      for (const w of batch) {
+        enqueue({
+          reason: 'retry',
+          agentId: w.agentId,
+          sessionKey: w.sessionKey,
+        });
+      }
+      schedule(DEFAULT_RETRY_MS, 'retry');
+    } finally {
+      running = false;
+      if (pending.size > 0 || scheduled) {
+        schedule(delay, 'normal');
+      }
+    }
+  };
+
+  const requestHeartbeatNow = (opts?: WakeOptions & { coalesceMs?: number }): void => {
+    enqueue({
+      reason: opts?.reason,
+      agentId: opts?.agentId,
+      sessionKey: opts?.sessionKey,
+    });
+    schedule(opts?.coalesceMs ?? DEFAULT_COALESCE_MS, 'normal');
+  };
+
+  const setHandler = (next: WakeHandler | null): (() => void) => {
+    handlerGeneration += 1;
+    const generation = handlerGeneration;
+    handler = next;
+    if (next) {
+      if (timer) clearTimeout(timer);
+      timer = null;
+      timerDueAt = null;
+      timerKind = null;
+      running = false;
+      scheduled = false;
+      if (pending.size > 0) {
+        schedule(DEFAULT_COALESCE_MS, 'normal');
+      }
+    }
+    return () => {
+      if (handlerGeneration !== generation) return;
+      if (handler !== next) return;
+      handlerGeneration += 1;
+      handler = null;
+    };
+  };
+
+  const hasPendingWake = (): boolean =>
+    pending.size > 0 || Boolean(timer) || scheduled;
+
+  const hydrate = async (): Promise<void> => {
+    try {
+      const rec = await chrome.storage?.session?.get?.(SESSION_STORAGE_KEY);
+      const raw = rec?.[SESSION_STORAGE_KEY];
+      if (!Array.isArray(raw)) return;
+      for (const item of raw) {
+        if (item && typeof item === 'object') {
+          const w = item as Partial<PendingWake>;
+          enqueue({
+            reason: w.reason,
+            requestedAt: w.requestedAt,
+            agentId: w.agentId,
+            sessionKey: w.sessionKey,
+          });
+        }
+      }
+      if (handler && pending.size > 0) {
+        schedule(DEFAULT_COALESCE_MS, 'normal');
+      }
+    } catch {
+      /* storage unavailable */
+    }
+  };
+
+  const _reset = (): void => {
+    if (timer) clearTimeout(timer);
+    timer = null;
+    timerDueAt = null;
+    timerKind = null;
+    pending.clear();
+    scheduled = false;
+    running = false;
+    handlerGeneration += 1;
+    handler = null;
+    persist();
+  };
+
+  return { requestHeartbeatNow, setHandler, hasPendingWake, hydrate, _reset };
+};
+
+export {
+  createWakeQueue,
+  DEFAULT_COALESCE_MS,
+  DEFAULT_RETRY_MS,
+  SESSION_STORAGE_KEY,
+  REASON_PRIORITY,
+};
+export type { WakeQueue, WakeHandler, WakeOptions, PendingWake };

--- a/chrome-extension/src/background/heartbeat/service/wake.ts
+++ b/chrome-extension/src/background/heartbeat/service/wake.ts
@@ -162,6 +162,7 @@ const createWakeQueue = (): WakeQueue => {
     pending.clear();
     persist();
     running = true;
+    const ranAgentKeys = new Set<string>();
     try {
       for (const w of batch) {
         const opts: WakeOptions = {
@@ -177,6 +178,10 @@ const createWakeQueue = (): WakeQueue => {
             sessionKey: w.sessionKey,
           });
           schedule(DEFAULT_RETRY_MS, 'retry');
+        } else {
+          // Track agents that ran (or were skipped for non-lock reasons) so we
+          // can drop stale wakes that accumulated during this run.
+          ranAgentKeys.add(targetKey(w.agentId, w.sessionKey));
         }
       }
     } catch {
@@ -190,6 +195,14 @@ const createWakeQueue = (): WakeQueue => {
       schedule(DEFAULT_RETRY_MS, 'retry');
     } finally {
       running = false;
+      // Drop pending wakes for agents that just ran successfully — they were
+      // enqueued during execution and are stale duplicates of the user's intent.
+      if (ranAgentKeys.size > 0) {
+        for (const key of ranAgentKeys) {
+          pending.delete(key);
+        }
+        persist();
+      }
       if (pending.size > 0 || scheduled) {
         schedule(delay, 'normal');
       }

--- a/chrome-extension/src/background/heartbeat/service/wake.ts
+++ b/chrome-extension/src/background/heartbeat/service/wake.ts
@@ -228,8 +228,7 @@ const createWakeQueue = (): WakeQueue => {
     };
   };
 
-  const hasPendingWake = (): boolean =>
-    pending.size > 0 || Boolean(timer) || scheduled;
+  const hasPendingWake = (): boolean => pending.size > 0 || Boolean(timer) || scheduled;
 
   const hydrate = async (): Promise<void> => {
     try {

--- a/chrome-extension/src/background/heartbeat/sleep-catchup.test.ts
+++ b/chrome-extension/src/background/heartbeat/sleep-catchup.test.ts
@@ -1,0 +1,97 @@
+// Service-level test: sleep catch-up (R20 / 02.25).
+//
+// When the host machine sleeps, in-memory state and alarms are paused. On
+// resume, the next `heartbeat-tick` may find `nextDueMs` hours in the past.
+// The service must collapse all that backlog into a single `runForAgent`
+// invocation and then rearm for `now + intervalMs`.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Keep the real chatDb (fake-indexeddb) but stub listAgents since HeartbeatService.refreshAgents calls it.
+vi.mock('@extension/storage', async () => {
+  const actual = await vi.importActual<typeof import('@extension/storage')>('@extension/storage');
+  return {
+    ...actual,
+    listAgents: vi.fn(async () => [{ id: 'a', name: 'a' } as never]),
+  };
+});
+
+vi.mock('./config', () => ({
+  loadHeartbeatConfig: vi.fn(async () => ({
+    enabled: true,
+    every: '30m',
+    ackMaxChars: 300,
+    target: 'last',
+  })),
+}));
+
+// Neutralise alarm calls in test env.
+vi.mock('./service/timer', async () => {
+  const actual = await vi.importActual<typeof import('./service/timer')>('./service/timer');
+  return {
+    ...actual,
+    scheduleTick: vi.fn(),
+    scheduleKick: vi.fn(),
+    clearAlarms: vi.fn(async () => {}),
+  };
+});
+
+// Stub runHeartbeatOnce to observe invocations without real work.
+const runOnceMock = vi.fn(async () => ({ status: 'ran' as const, chatId: 'c1' }));
+vi.mock('./service/run-once', () => ({
+  runHeartbeatOnce: (...args: unknown[]) => runOnceMock(...args),
+}));
+
+import { HeartbeatService } from './service';
+
+const makeLog = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  trace: vi.fn(),
+});
+
+describe('HeartbeatService sleep catch-up', () => {
+  beforeEach(async () => {
+    const { chatDb } = await import('@extension/storage');
+    await chatDb.heartbeatLocks.clear();
+    await chatDb.heartbeatState.clear();
+    vi.useFakeTimers();
+    runOnceMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('collapses a backlog into a single run and rearms nextDueMs to now+interval', async () => {
+    const intervalMs = 30 * 60_000;
+    let fakeNow = Date.UTC(2026, 3, 1, 12, 0, 0);
+    const svc = new HeartbeatService({ log: makeLog(), nowMs: () => fakeNow });
+    await svc.start();
+
+    // Force the agent's nextDueMs 8 hours in the past.
+    const snap = svc.getAgentSnapshots();
+    expect(snap).toHaveLength(1);
+    // Reach into internal state to simulate post-sleep drift.
+    // biome-ignore lint/suspicious/noExplicitAny: test hook
+    const agents = (svc as unknown as { state: { agents: Map<string, { nextDueMs: number }> } })
+      .state.agents;
+    agents.get('a')!.nextDueMs = fakeNow - 8 * 60 * 60_000;
+
+    // Fire alarm; handleAlarm sweeps due agents through the wake queue.
+    await svc.handleAlarm({ name: 'heartbeat-tick' } as chrome.alarms.Alarm);
+
+    // Wake queue coalesces with a ~250ms timer; advance it.
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(runOnceMock).toHaveBeenCalledTimes(1);
+
+    // nextDueMs should now be in the future (~now + interval), NOT another
+    // backlog step.
+    const after = agents.get('a')!.nextDueMs;
+    expect(after).toBeGreaterThanOrEqual(fakeNow);
+    expect(after - fakeNow).toBeLessThanOrEqual(intervalMs + 1_000);
+  });
+});

--- a/chrome-extension/src/background/heartbeat/sleep-catchup.test.ts
+++ b/chrome-extension/src/background/heartbeat/sleep-catchup.test.ts
@@ -5,6 +5,7 @@
 // The service must collapse all that backlog into a single `runForAgent`
 // invocation and then rearm for `now + intervalMs`.
 
+import { HeartbeatService } from './service';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Keep the real chatDb (fake-indexeddb) but stub listAgents since HeartbeatService.refreshAgents calls it.
@@ -23,6 +24,7 @@ vi.mock('./config', () => ({
     ackMaxChars: 300,
     target: 'last',
   })),
+  isHeartbeatEnabledForAgent: vi.fn(async () => true),
 }));
 
 // Neutralise alarm calls in test env.
@@ -41,8 +43,6 @@ const runOnceMock = vi.fn(async () => ({ status: 'ran' as const, chatId: 'c1' })
 vi.mock('./service/run-once', () => ({
   runHeartbeatOnce: (...args: unknown[]) => runOnceMock(...args),
 }));
-
-import { HeartbeatService } from './service';
 
 const makeLog = () => ({
   debug: vi.fn(),
@@ -67,7 +67,7 @@ describe('HeartbeatService sleep catch-up', () => {
 
   it('collapses a backlog into a single run and rearms nextDueMs to now+interval', async () => {
     const intervalMs = 30 * 60_000;
-    let fakeNow = Date.UTC(2026, 3, 1, 12, 0, 0);
+    const fakeNow = Date.UTC(2026, 3, 1, 12, 0, 0);
     const svc = new HeartbeatService({ log: makeLog(), nowMs: () => fakeNow });
     await svc.start();
 

--- a/chrome-extension/src/background/heartbeat/transcript-prune.test.ts
+++ b/chrome-extension/src/background/heartbeat/transcript-prune.test.ts
@@ -1,0 +1,66 @@
+// Unit tests for transcript prune (R20 / 02.23).
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { snapshotMaxMessageId, pruneMessagesAbove } from './transcript-prune';
+
+describe('transcript-prune', () => {
+  beforeEach(async () => {
+    const { chatDb } = await import('@extension/storage');
+    await chatDb.messages.clear();
+  });
+
+  const addMsg = async (chatId: string, id: string, text = 'x') => {
+    const { chatDb } = await import('@extension/storage');
+    await chatDb.messages.put({
+      id,
+      chatId,
+      role: 'user',
+      parts: [{ type: 'text', text }],
+      createdAt: Date.now(),
+    });
+  };
+
+  it('returns null snapshot for an empty chat', async () => {
+    expect(await snapshotMaxMessageId('chat-empty')).toBeNull();
+  });
+
+  it('captures the lexically-greatest id', async () => {
+    await addMsg('c', 'aaa');
+    await addMsg('c', 'ccc');
+    await addMsg('c', 'bbb');
+    expect(await snapshotMaxMessageId('c')).toBe('ccc');
+  });
+
+  it('prunes only messages strictly above snapshot', async () => {
+    await addMsg('c', 'm1');
+    await addMsg('c', 'm2');
+    const snap = await snapshotMaxMessageId('c');
+    await addMsg('c', 'm3');
+    await addMsg('c', 'm4');
+
+    const deleted = await pruneMessagesAbove('c', snap);
+    expect(deleted).toBe(2);
+
+    const { chatDb } = await import('@extension/storage');
+    const remaining = await chatDb.messages.where('chatId').equals('c').toArray();
+    expect(remaining.map(m => m.id).sort()).toEqual(['m1', 'm2']);
+  });
+
+  it('prunes everything when snapshot is null', async () => {
+    await addMsg('c', 'm1');
+    await addMsg('c', 'm2');
+    const deleted = await pruneMessagesAbove('c', null);
+    expect(deleted).toBe(2);
+
+    const { chatDb } = await import('@extension/storage');
+    expect(await chatDb.messages.where('chatId').equals('c').count()).toBe(0);
+  });
+
+  it('does not touch messages in other chats', async () => {
+    await addMsg('a', 'a1');
+    await addMsg('b', 'b1');
+    await pruneMessagesAbove('a', null);
+    const { chatDb } = await import('@extension/storage');
+    expect(await chatDb.messages.where('chatId').equals('b').count()).toBe(1);
+  });
+});

--- a/chrome-extension/src/background/heartbeat/transcript-prune.test.ts
+++ b/chrome-extension/src/background/heartbeat/transcript-prune.test.ts
@@ -1,7 +1,7 @@
 // Unit tests for transcript prune (R20 / 02.23).
 
-import { beforeEach, describe, expect, it } from 'vitest';
 import { snapshotMaxMessageId, pruneMessagesAbove } from './transcript-prune';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('transcript-prune', () => {
   beforeEach(async () => {

--- a/chrome-extension/src/background/heartbeat/transcript-prune.ts
+++ b/chrome-extension/src/background/heartbeat/transcript-prune.ts
@@ -28,10 +28,7 @@ const snapshotMaxMessageId = async (chatId: string): Promise<string | null> => {
  *
  * A null snapshot means "chat was empty at snapshot time" — prune everything.
  */
-const pruneMessagesAbove = async (
-  chatId: string,
-  snapshotId: string | null,
-): Promise<number> => {
+const pruneMessagesAbove = async (chatId: string, snapshotId: string | null): Promise<number> => {
   const all = await chatDb.messages.where('chatId').equals(chatId).toArray();
   const toDelete = snapshotId === null ? all : all.filter(m => m.id > snapshotId);
   if (toDelete.length === 0) return 0;

--- a/chrome-extension/src/background/heartbeat/transcript-prune.ts
+++ b/chrome-extension/src/background/heartbeat/transcript-prune.ts
@@ -1,0 +1,42 @@
+// ── Transcript prune ────────────────────────────
+// Replaces OpenClaw's fs-based `fs.truncate` with a Dexie-level equivalent.
+//
+// A "snapshot" is the highest message id observed for a chat at the start of
+// a heartbeat run. If the run is later classified as skip (empty HEARTBEAT.md
+// ack, dedup hit, effectively-empty response), we delete every message strictly
+// added after the snapshot so the chat transcript looks unchanged.
+
+import { chatDb } from '@extension/storage';
+
+/**
+ * Capture the lexically-greatest message id for a chat. Returns `null` when
+ * the chat has no messages yet.
+ */
+const snapshotMaxMessageId = async (chatId: string): Promise<string | null> => {
+  const messages = await chatDb.messages.where('chatId').equals(chatId).toArray();
+  if (messages.length === 0) return null;
+  let max = messages[0]!.id;
+  for (let i = 1; i < messages.length; i++) {
+    if (messages[i]!.id > max) max = messages[i]!.id;
+  }
+  return max;
+};
+
+/**
+ * Delete every message in the chat whose id is strictly greater than
+ * `snapshotId`. Returns the number of rows deleted.
+ *
+ * A null snapshot means "chat was empty at snapshot time" — prune everything.
+ */
+const pruneMessagesAbove = async (
+  chatId: string,
+  snapshotId: string | null,
+): Promise<number> => {
+  const all = await chatDb.messages.where('chatId').equals(chatId).toArray();
+  const toDelete = snapshotId === null ? all : all.filter(m => m.id > snapshotId);
+  if (toDelete.length === 0) return 0;
+  await chatDb.messages.bulkDelete(toDelete.map(m => m.id));
+  return toDelete.length;
+};
+
+export { snapshotMaxMessageId, pruneMessagesAbove };

--- a/chrome-extension/src/background/heartbeat/types.ts
+++ b/chrome-extension/src/background/heartbeat/types.ts
@@ -1,0 +1,104 @@
+// ── Types used across the heartbeat subsystem ────
+// Plain-object schemas. Kept separate so cycles between prompt / config /
+// service modules remain impossible.
+
+interface HeartbeatActiveHoursConfig {
+  start: string; // "HH:MM" 24-hour
+  end: string; // "HH:MM" 24-hour (24:00 allowed)
+  /** IANA zone, "user" / "local", or undefined for host zone. */
+  timezone?: string;
+}
+
+interface HeartbeatVisibilityConfig {
+  showOk?: boolean;
+  showAlerts?: boolean;
+  useIndicator?: boolean;
+}
+
+/**
+ * Per-agent heartbeat config persisted in `chrome.storage.local` under
+ * `heartbeat.<agentId>`. Global defaults live at `heartbeat.defaults`.
+ */
+interface HeartbeatConfig {
+  enabled: boolean;
+  /** Duration string, e.g. "30m", "1h". Defaults to DEFAULT_HEARTBEAT_EVERY. */
+  every: string;
+  /** Per-agent model override — model id or name. */
+  model?: string;
+  /** Overrides the default heartbeat prompt. */
+  prompt?: string;
+  /** Max chars that still count as an ack ("HEARTBEAT_OK + note"). */
+  ackMaxChars?: number;
+  /** 'last' = latest active channel; 'none' = suppress delivery; channel id otherwise. */
+  target?: 'last' | 'none' | string;
+  /** Recipient / chat id inside the channel. */
+  to?: string;
+  activeHours?: HeartbeatActiveHoursConfig;
+  /** If true, skip heavy workspace context when prompting. */
+  lightContext?: boolean;
+  /** If true, request model reasoning. */
+  includeReasoning?: boolean;
+  visibility?: HeartbeatVisibilityConfig;
+}
+
+/** Normalized classification of why a tick is firing. */
+type HeartbeatReason =
+  | 'interval'
+  | 'manual'
+  | 'retry'
+  | 'exec-event'
+  | 'wake'
+  | 'other'
+  | `cron:${string}`;
+
+type HeartbeatTriggerKind =
+  | 'interval'
+  | 'manual'
+  | 'retry'
+  | 'exec-event'
+  | 'wake'
+  | 'cron'
+  | 'other';
+
+interface HeartbeatTrigger {
+  kind: HeartbeatTriggerKind | string;
+  /** Optional descriptor (e.g. cron job id) appended after ':' in the reason. */
+  detail?: string;
+  /** Arbitrary metadata; ignored for routing but carried in events. */
+  meta?: Record<string, unknown>;
+}
+
+type HeartbeatRunStatus = 'ran' | 'skipped' | 'failed';
+
+interface HeartbeatRunResult {
+  status: HeartbeatRunStatus;
+  reason?: string;
+  chatId?: string;
+  durationMs?: number;
+}
+
+interface HeartbeatEvent {
+  agentId: string;
+  /** Monotonic timestamp. */
+  atMs: number;
+  /** Normalized classification. */
+  reason: HeartbeatReason;
+  status: HeartbeatRunStatus | 'requested' | 'started';
+  chatId?: string;
+  error?: string;
+  durationMs?: number;
+  /** Short, user-presentable description of the outcome. */
+  summary?: string;
+}
+
+export type {
+  HeartbeatActiveHoursConfig,
+  HeartbeatVisibilityConfig,
+  HeartbeatConfig,
+  HeartbeatReason,
+  HeartbeatTriggerKind,
+  HeartbeatTrigger,
+  HeartbeatRunStatus,
+  HeartbeatRunResult,
+  HeartbeatEvent,
+};

--- a/chrome-extension/src/background/heartbeat/visibility.ts
+++ b/chrome-extension/src/background/heartbeat/visibility.ts
@@ -1,0 +1,37 @@
+// ── Visibility resolution ───────────────────────
+// Simplified from OpenClaw's multi-layer (cfg/channel/account) resolver —
+// ChromeClaw has only a per-agent config + defaults layer.
+
+import type { HeartbeatConfig, HeartbeatVisibilityConfig } from './types';
+
+interface ResolvedHeartbeatVisibility {
+  showOk: boolean;
+  showAlerts: boolean;
+  useIndicator: boolean;
+}
+
+const DEFAULT_VISIBILITY: ResolvedHeartbeatVisibility = {
+  showOk: false,
+  showAlerts: true,
+  useIndicator: true,
+};
+
+/**
+ * Merge per-agent visibility config with defaults. Unset fields fall through
+ * to `DEFAULT_VISIBILITY` (silent OKs, visible alerts, on-screen indicator).
+ */
+const resolveVisibility = (
+  config: HeartbeatConfig | undefined,
+  defaults?: HeartbeatVisibilityConfig,
+): ResolvedHeartbeatVisibility => {
+  const perAgent = config?.visibility;
+  return {
+    showOk: perAgent?.showOk ?? defaults?.showOk ?? DEFAULT_VISIBILITY.showOk,
+    showAlerts: perAgent?.showAlerts ?? defaults?.showAlerts ?? DEFAULT_VISIBILITY.showAlerts,
+    useIndicator:
+      perAgent?.useIndicator ?? defaults?.useIndicator ?? DEFAULT_VISIBILITY.useIndicator,
+  };
+};
+
+export { resolveVisibility, DEFAULT_VISIBILITY };
+export type { ResolvedHeartbeatVisibility };

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -379,7 +379,10 @@ const messageHandlers: Record<string, MessageHandler> = {
       const { getProviderTokenLimit } = await import('./context/provider-limit-cache');
 
       const [messages, chat] = await Promise.all([getMessagesByChatId(chatId), getChat(chatId)]);
-      slashCmdLog.debug('Loaded messages for compaction', { chatId, messageCount: messages.length });
+      slashCmdLog.debug('Loaded messages for compaction', {
+        chatId,
+        messageCount: messages.length,
+      });
       if (messages.length <= 2) return { error: 'Not enough messages to compact' };
 
       // Build system prompt to get accurate token count (same as stream-handler.ts)

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -14,6 +14,7 @@ import {
 } from './channels/poller';
 import { CronService, readRunLogs } from './cron';
 import { executeScheduledTask } from './cron/executor';
+import { HeartbeatService, setHeartbeatServiceRef } from './heartbeat';
 import {
   createLogger,
   configReady,
@@ -45,6 +46,32 @@ const cronService = new CronService({
 });
 
 setCronServiceRef(cronService);
+
+// ── Heartbeat subsystem ─────────────────────────
+const heartbeatLog = createLogger('heartbeat');
+const heartbeatService = new HeartbeatService({
+  log: heartbeatLog,
+  onEvent: evt => {
+    chrome.runtime.sendMessage({ type: 'HEARTBEAT_EVENT', ...evt }).catch(() => {});
+  },
+});
+setHeartbeatServiceRef(heartbeatService);
+Promise.resolve().then(() =>
+  heartbeatService.start().catch(err => {
+    heartbeatLog.error('Failed to start heartbeat service', { error: String(err) });
+  }),
+);
+
+chrome.runtime.onInstalled.addListener(() => {
+  heartbeatService.start().catch(err => {
+    heartbeatLog.error('onInstalled heartbeat start failed', { error: String(err) });
+  });
+});
+chrome.runtime.onStartup.addListener(() => {
+  heartbeatService.start().catch(err => {
+    heartbeatLog.error('onStartup heartbeat start failed', { error: String(err) });
+  });
+});
 
 // Start cron — use microtask to avoid setTimeout race with Firefox event page suspension.
 // IndexedDB is available immediately; the 1-second delay was unnecessary and risky.
@@ -103,6 +130,13 @@ const messageHandlers: Record<string, MessageHandler> = {
 
   CLEAR_LOGS: async () => {
     clearLogEntries();
+    return { success: true };
+  },
+
+  HEARTBEAT_RUN_NOW: async request => {
+    const agentId = typeof request.agentId === 'string' ? request.agentId : undefined;
+    if (!agentId) return { success: false, error: 'agentId required' };
+    heartbeatService.requestHeartbeatNow({ reason: 'manual', agentId });
     return { success: true };
   },
 
@@ -478,7 +512,11 @@ chrome.runtime.onConnect.addListener(port => {
 // Handle alarms: keep-alive, channel passive polls, and watchdog.
 // Use waitUntil pattern (returning promise) to keep SW alive during async poll work.
 chrome.alarms.onAlarm.addListener(alarm => {
-  if (CronService.isSchedulerAlarm(alarm.name)) {
+  if (HeartbeatService.isSchedulerAlarm(alarm.name)) {
+    heartbeatService.handleAlarm(alarm).catch(err => {
+      heartbeatLog.error('Heartbeat alarm handler failed', { error: String(err) });
+    });
+  } else if (CronService.isSchedulerAlarm(alarm.name)) {
     cronService.handleAlarm().catch(err => {
       cronLog.error('Cron alarm handler failed', { error: String(err) });
     });

--- a/packages/config-panels/lib/agents-config.test.ts
+++ b/packages/config-panels/lib/agents-config.test.ts
@@ -23,13 +23,14 @@ beforeEach(async () => {
 });
 
 describe('AgentsConfig — workspace file list', () => {
-  it('lists 6 predefined core files (excluding skills)', async () => {
+  it('lists 7 predefined core files (excluding skills)', async () => {
     const files = await listUserWorkspaceFiles();
     const nonSkill = files.filter(f => !isSkillFile(f.name));
-    expect(nonSkill.length).toBe(6);
+    expect(nonSkill.length).toBe(7);
     const names = nonSkill.map(f => f.name).sort();
     expect(names).toEqual([
       'AGENTS.md',
+      'HEARTBEAT.md',
       'IDENTITY.md',
       'MEMORY.md',
       'SOUL.md',
@@ -105,7 +106,7 @@ describe('AgentsConfig — workspace file list', () => {
 
     const files = await listUserWorkspaceFiles();
     const nonSkill = files.filter(f => !isSkillFile(f.name));
-    expect(nonSkill.length).toBe(7); // 6 predefined + 1 custom
+    expect(nonSkill.length).toBe(8); // 7 predefined + 1 custom
     const custom = nonSkill.find(f => f.id === 'custom-file-1');
     expect(custom).toBeDefined();
     expect(custom!.predefined).toBe(false);

--- a/packages/config-panels/lib/agents-config.tsx
+++ b/packages/config-panels/lib/agents-config.tsx
@@ -1,3 +1,5 @@
+import { ConfirmDialog, emptyConfirm } from './confirm-dialog.js';
+import { SkillConfig } from './skill-config.js';
 import { t, useT } from '@extension/i18n';
 import {
   extractPdfText,
@@ -23,7 +25,6 @@ import {
   activeAgentStorage,
   toolConfigStorage,
   chatDb,
-  type DbHeartbeatState,
 } from '@extension/storage';
 import {
   Badge,
@@ -55,6 +56,7 @@ import {
   buildFileTree,
   cn,
 } from '@extension/ui';
+import JSZip from 'jszip';
 import {
   BrainIcon,
   CalendarClockIcon,
@@ -86,20 +88,18 @@ import {
   UsersIcon,
   WrenchIcon,
 } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
 import { nanoid } from 'nanoid';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import JSZip from 'jszip';
 import { toast } from 'sonner';
+import type { ConfirmDialogState } from './confirm-dialog.js';
 import type {
+  DbHeartbeatState,
   DbWorkspaceFile,
   AgentConfig,
   ToolConfig as ToolConfigData,
 } from '@extension/storage';
 import type { FileTreeNode } from '@extension/ui';
-import { ConfirmDialog, emptyConfirm } from './confirm-dialog.js';
-import type { ConfirmDialogState } from './confirm-dialog.js';
-import { SkillConfig } from './skill-config.js';
+import type { LucideIcon } from 'lucide-react';
 
 const MAX_CONTENT_LENGTH = 20_000;
 

--- a/packages/config-panels/lib/agents-config.tsx
+++ b/packages/config-panels/lib/agents-config.tsx
@@ -22,6 +22,8 @@ import {
   copyGlobalSkillsToAgent,
   activeAgentStorage,
   toolConfigStorage,
+  chatDb,
+  type DbHeartbeatState,
 } from '@extension/storage';
 import {
   Badge,
@@ -420,6 +422,76 @@ const AgentDetailHeader = ({
 };
 
 type OverviewField = { label: string; value: string };
+
+const HeartbeatStatusCard = ({ agentId }: { agentId: string }) => {
+  const [state, setState] = useState<DbHeartbeatState | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const row = await chatDb.heartbeatState.get(agentId);
+      setState(row ?? null);
+    } catch {
+      setState(null);
+    }
+  }, [agentId]);
+
+  useEffect(() => {
+    void load();
+    const listener = (msg: Record<string, unknown>) => {
+      if (msg?.type === 'HEARTBEAT_EVENT' && msg.agentId === agentId) {
+        void load();
+      }
+    };
+    try {
+      chrome.runtime.onMessage.addListener(listener);
+    } catch {
+      /* ignore */
+    }
+    return () => {
+      try {
+        chrome.runtime.onMessage.removeListener(listener);
+      } catch {
+        /* ignore */
+      }
+    };
+  }, [agentId, load]);
+
+  const runNow = useCallback(async () => {
+    setBusy(true);
+    try {
+      await chrome.runtime.sendMessage({ type: 'HEARTBEAT_RUN_NOW', agentId });
+    } catch {
+      /* ignore */
+    } finally {
+      setBusy(false);
+    }
+  }, [agentId]);
+
+  const formatTime = (ms?: number) =>
+    typeof ms === 'number' ? new Date(ms).toLocaleString() : '—';
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-sm">Heartbeat</CardTitle>
+        <Button size="sm" variant="outline" disabled={busy} onClick={runNow}>
+          {busy ? 'Running…' : 'Run now'}
+        </Button>
+      </CardHeader>
+      <CardContent className="text-muted-foreground space-y-1 text-sm">
+        <div>Last run: {formatTime(state?.lastRunAtMs)}</div>
+        <div>
+          Status: {state?.lastStatus ?? '—'}
+          {state?.lastReason ? ` (${state.lastReason})` : ''}
+        </div>
+        {state?.lastResultSummary && (
+          <div className="truncate">Summary: {state.lastResultSummary}</div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
 
 const AgentOverview = ({ identityContent }: { identityContent: string }) => {
   const t = useT();
@@ -1767,6 +1839,7 @@ const AgentsConfig = () => {
               <ScrollArea className="flex-1">
                 <div className="space-y-4 p-6">
                   <AgentOverview identityContent={identityContent} />
+                  <HeartbeatStatusCard agentId={selectedAgentId} />
                   <Card>
                     <CardHeader>
                       <CardTitle className="text-sm">{t('agents_workspaceFiles')}</CardTitle>

--- a/packages/i18n/locales/en/messages.json
+++ b/packages/i18n/locales/en/messages.json
@@ -437,6 +437,9 @@
   "toast_scheduledTaskFired": {
     "message": "Scheduled task fired"
   },
+  "toast_heartbeatDelivered": {
+    "message": "Heartbeat alert"
+  },
   "toast_newTelegramMessage": {
     "message": "New Telegram message"
   },

--- a/packages/shared/lib/logger.ts
+++ b/packages/shared/lib/logger.ts
@@ -30,6 +30,7 @@ type LogCategory =
   | 'media'
   | 'journal'
   | 'cron'
+  | 'heartbeat'
   | 'tts'
   | 'local-llm'
   | 'embedding'

--- a/packages/storage/lib/impl/chat-db.ts
+++ b/packages/storage/lib/impl/chat-db.ts
@@ -206,6 +206,26 @@ interface DbTaskRunLog {
   chatId?: string;
 }
 
+/** DB-level heartbeat per-agent state (v14). */
+interface DbHeartbeatState {
+  agentId: string;
+  lastRunAtMs?: number;
+  lastStatus?: 'ran' | 'skipped' | 'failed';
+  lastReason?: string;
+  lastResultSummary?: string;
+  lastHeartbeatText?: string;
+  lastHeartbeatSentAt?: number;
+  lastChatId?: string;
+}
+
+/** DB-level TTL lock for an in-flight heartbeat run (v14). */
+interface DbHeartbeatLock {
+  agentId: string;
+  acquiredAt: number;
+  expiresAt: number;
+  reason?: string;
+}
+
 const chatDb = new Dexie('chromeclaw') as InstanceType<typeof Dexie> & {
   agents: EntityTable<AgentConfig, 'id'>;
   chats: EntityTable<DbChat, 'id'>;
@@ -216,6 +236,8 @@ const chatDb = new Dexie('chromeclaw') as InstanceType<typeof Dexie> & {
   scheduledTasks: EntityTable<DbScheduledTask, 'id'>;
   taskRunLogs: EntityTable<DbTaskRunLog, 'id'>;
   embeddingCache: EntityTable<DbEmbeddingCache, 'id'>;
+  heartbeatState: EntityTable<DbHeartbeatState, 'agentId'>;
+  heartbeatLocks: EntityTable<DbHeartbeatLock, 'agentId'>;
 };
 
 chatDb.version(1).stores({
@@ -405,6 +427,22 @@ chatDb.version(13).stores({
 });
 // No upgrade function needed — chatId is optional, existing chunks don't have it
 
+// v14: adds heartbeatState + heartbeatLocks for the heartbeat subsystem
+chatDb.version(14).stores({
+  agents: 'id, isDefault',
+  chats: 'id, updatedAt, source, agentId',
+  messages: 'id, chatId, createdAt',
+  artifacts: 'id, chatId',
+  workspaceFiles: 'id, owner, agentId',
+  memoryChunks: 'id, fileId, filePath, agentId, chatId',
+  scheduledTasks: 'id, enabled',
+  taskRunLogs: 'id, taskId, timestamp',
+  embeddingCache: 'id, contentHash, updatedAt',
+  heartbeatState: 'agentId, lastRunAtMs',
+  heartbeatLocks: 'agentId, expiresAt',
+});
+// No upgrade function needed — new tables start empty
+
 // Seed the default 'main' agent on fresh installs.
 // The v10 upgrade only runs when migrating from v9; a brand-new DB skips it.
 chatDb.on('populate', () => {
@@ -435,5 +473,7 @@ export type {
   DbScheduledTask,
   DbTaskRunLog,
   DbEmbeddingCache,
+  DbHeartbeatState,
+  DbHeartbeatLock,
 };
 export { chatDb };

--- a/packages/storage/lib/impl/chat-storage.ts
+++ b/packages/storage/lib/impl/chat-storage.ts
@@ -1,5 +1,4 @@
 import { chatDb } from './chat-db.js';
-import { isSkillFile, parseSkillFrontmatter, DAILY_JOURNAL_SKILL, SKILL_CREATOR_SKILL, TOOL_CREATOR_SKILL } from '@extension/skills';
 import {
   AGENTS_DEFAULT,
   SOUL_DEFAULT,
@@ -8,6 +7,13 @@ import {
   TOOLS_DEFAULT,
   HEARTBEAT_DEFAULT,
 } from './workspace-defaults.js';
+import {
+  isSkillFile,
+  parseSkillFrontmatter,
+  DAILY_JOURNAL_SKILL,
+  SKILL_CREATOR_SKILL,
+  TOOL_CREATOR_SKILL,
+} from '@extension/skills';
 import { nanoid } from 'nanoid';
 import type {
   DbChat,
@@ -40,7 +46,12 @@ const listAgents = async (): Promise<AgentConfig[]> => chatDb.agents.toArray();
 
 const updateAgent = async (
   id: string,
-  updates: Partial<Pick<AgentConfig, 'name' | 'identity' | 'model' | 'toolConfig' | 'customTools' | 'compactionConfig'>>,
+  updates: Partial<
+    Pick<
+      AgentConfig,
+      'name' | 'identity' | 'model' | 'toolConfig' | 'customTools' | 'compactionConfig'
+    >
+  >,
 ): Promise<void> => {
   await chatDb.agents.update(id, { ...updates, updatedAt: Date.now() });
 };
@@ -368,10 +379,10 @@ const seedPredefinedWorkspaceFiles = async (agentId = 'main'): Promise<void> => 
 
   // Migrate existing global skill files to agent-scoped
   const allFiles = await chatDb.workspaceFiles.toArray();
-  const globalSkills = allFiles.filter(f => f.predefined && isSkillFile(f.name) && (!f.agentId || f.agentId === ''));
-  const agentExistingNames = new Set(
-    allFiles.filter(f => f.agentId === agentId).map(f => f.name),
+  const globalSkills = allFiles.filter(
+    f => f.predefined && isSkillFile(f.name) && (!f.agentId || f.agentId === ''),
   );
+  const agentExistingNames = new Set(allFiles.filter(f => f.agentId === agentId).map(f => f.name));
   const migratedSkills = globalSkills
     .filter(f => !agentExistingNames.has(f.name))
     .map(f => ({
@@ -388,22 +399,24 @@ const seedPredefinedWorkspaceFiles = async (agentId = 'main'): Promise<void> => 
 
   // Seed agent-scoped predefined workspace files (including skills)
   const agentExisting = allFiles.filter(f => f.agentId === agentId);
-  const agentExistingPredefinedNames = new Set(agentExisting.filter(f => f.predefined).map(f => f.name));
+  const agentExistingPredefinedNames = new Set(
+    agentExisting.filter(f => f.predefined).map(f => f.name),
+  );
   // Also exclude names we're about to migrate
   const migratedNames = new Set(migratedSkills.map(f => f.name));
-  const agentFiles = PREDEFINED_FILES
-    .filter(f => !agentExistingPredefinedNames.has(f.name) && !migratedNames.has(f.name))
-    .map(f => ({
-      id: nanoid(),
-      name: f.name,
-      content: f.content,
-      enabled: 'enabled' in f ? f.enabled : true,
-      owner: 'user' as const,
-      predefined: true,
-      createdAt: now,
-      updatedAt: now,
-      agentId,
-    }));
+  const agentFiles = PREDEFINED_FILES.filter(
+    f => !agentExistingPredefinedNames.has(f.name) && !migratedNames.has(f.name),
+  ).map(f => ({
+    id: nanoid(),
+    name: f.name,
+    content: f.content,
+    enabled: 'enabled' in f ? f.enabled : true,
+    owner: 'user' as const,
+    predefined: true,
+    createdAt: now,
+    updatedAt: now,
+    agentId,
+  }));
 
   const toCreate = [...migratedSkills, ...agentFiles];
   if (toCreate.length > 0) {

--- a/packages/storage/lib/impl/chat-storage.ts
+++ b/packages/storage/lib/impl/chat-storage.ts
@@ -6,6 +6,7 @@ import {
   USER_DEFAULT,
   IDENTITY_DEFAULT,
   TOOLS_DEFAULT,
+  HEARTBEAT_DEFAULT,
 } from './workspace-defaults.js';
 import { nanoid } from 'nanoid';
 import type {
@@ -356,6 +357,7 @@ const PREDEFINED_FILES = [
   { name: 'IDENTITY.md', content: IDENTITY_DEFAULT },
   { name: 'TOOLS.md', content: TOOLS_DEFAULT },
   { name: 'MEMORY.md', content: '' },
+  { name: 'HEARTBEAT.md', content: HEARTBEAT_DEFAULT },
   { name: 'skills/daily-journal/SKILL.md', content: DAILY_JOURNAL_SKILL, enabled: false },
   { name: 'skills/skill-creator/SKILL.md', content: SKILL_CREATOR_SKILL, enabled: false },
   { name: 'skills/tool-creator/SKILL.md', content: TOOL_CREATOR_SKILL, enabled: false },

--- a/packages/storage/lib/impl/chat-storage.ts
+++ b/packages/storage/lib/impl/chat-storage.ts
@@ -56,8 +56,10 @@ const updateAgent = async (
   await chatDb.agents.update(id, { ...updates, updatedAt: Date.now() });
 };
 
+// Note: `.where('isDefault').equals(1)` won't work because Chrome's IndexedDB
+// treats boolean `true` and numeric `1` as distinct index keys. Use .filter().
 const getDefaultAgent = async (): Promise<AgentConfig | undefined> =>
-  chatDb.agents.where('isDefault').equals(1).first();
+  chatDb.agents.filter(a => !!a.isDefault).first();
 
 const deleteAgent = async (id: string): Promise<void> => {
   const agent = await chatDb.agents.get(id);

--- a/packages/storage/lib/impl/workspace-defaults.ts
+++ b/packages/storage/lib/impl/workspace-defaults.ts
@@ -123,6 +123,42 @@ _Fill this in during your first conversation. Make it yours._
 This isn't just metadata. It's the start of figuring out who you are.
 `;
 
+const HEARTBEAT_DEFAULT = `# HEARTBEAT.md - Periodic Check-In
+
+This file drives the heartbeat subsystem — a periodic, agent-run check-in that
+inspects the current world (pending events, memory, open conversations) and
+either:
+
+1. Sends a short alert via an active channel when something matters, or
+2. Replies with the single token \`HEARTBEAT_OK\` (silently suppressed).
+
+## How It Works
+
+Every interval (default 30 minutes) the agent is woken with a short headless
+LLM session. It reads this file, pending system events, and its workspace.
+If there is nothing interesting to say, reply \`HEARTBEAT_OK\` — do NOT send
+any filler. Duplicate alerts within 24 hours are suppressed.
+
+## What To Watch For
+
+- Time-sensitive obligations surfaced in MEMORY.md (reminders, follow-ups)
+- Pending system events (\`taskRunLogs\`) or cron output that needs triage
+- Anything the user explicitly asked you to check on periodically
+
+## What NOT To Do
+
+- Do not chat, greet, or narrate "I am checking in"
+- Do not send status updates unless there's actionable content
+- Do not repeat an alert you already delivered in the last 24 hours
+- When unsure, output exactly \`HEARTBEAT_OK\`
+
+## Editing This File
+
+Blank or trivial (whitespace / headers only) content disables interval ticks
+— explicit manual runs and cron-originated wakes still execute. Add lines
+that describe what to watch for and the heartbeat becomes useful.
+`;
+
 const TOOLS_DEFAULT = `# TOOLS.md - Local Notes
 
 This file is for your specifics — things unique to this user's setup.
@@ -160,6 +196,7 @@ export {
   USER_DEFAULT,
   IDENTITY_DEFAULT,
   TOOLS_DEFAULT,
+  HEARTBEAT_DEFAULT,
   DAILY_JOURNAL_SKILL,
   SKILL_CREATOR_SKILL,
   TOOL_CREATOR_SKILL,

--- a/packages/storage/lib/impl/workspace-defaults.ts
+++ b/packages/storage/lib/impl/workspace-defaults.ts
@@ -123,40 +123,10 @@ _Fill this in during your first conversation. Make it yours._
 This isn't just metadata. It's the start of figuring out who you are.
 `;
 
-const HEARTBEAT_DEFAULT = `# HEARTBEAT.md - Periodic Check-In
+const HEARTBEAT_DEFAULT = `# HEARTBEAT.md
 
-This file drives the heartbeat subsystem — a periodic, agent-run check-in that
-inspects the current world (pending events, memory, open conversations) and
-either:
-
-1. Sends a short alert via an active channel when something matters, or
-2. Replies with the single token \`HEARTBEAT_OK\` (silently suppressed).
-
-## How It Works
-
-Every interval (default 30 minutes) the agent is woken with a short headless
-LLM session. It reads this file, pending system events, and its workspace.
-If there is nothing interesting to say, reply \`HEARTBEAT_OK\` — do NOT send
-any filler. Duplicate alerts within 24 hours are suppressed.
-
-## What To Watch For
-
-- Time-sensitive obligations surfaced in MEMORY.md (reminders, follow-ups)
-- Pending system events (\`taskRunLogs\`) or cron output that needs triage
-- Anything the user explicitly asked you to check on periodically
-
-## What NOT To Do
-
-- Do not chat, greet, or narrate "I am checking in"
-- Do not send status updates unless there's actionable content
-- Do not repeat an alert you already delivered in the last 24 hours
-- When unsure, output exactly \`HEARTBEAT_OK\`
-
-## Editing This File
-
-Blank or trivial (whitespace / headers only) content disables interval ticks
-— explicit manual runs and cron-originated wakes still execute. Add lines
-that describe what to watch for and the heartbeat becomes useful.
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+# Add tasks below when you want the agent to check something periodically.
 `;
 
 const TOOLS_DEFAULT = `# TOOLS.md - Local Notes

--- a/packages/storage/lib/impl/workspace-files.test.ts
+++ b/packages/storage/lib/impl/workspace-files.test.ts
@@ -123,17 +123,17 @@ describe('Workspace File CRUD', () => {
 });
 
 describe('Predefined File Seeding', () => {
-  it('seedPredefinedWorkspaceFiles creates 8 files on empty table', async () => {
+  it('seedPredefinedWorkspaceFiles creates 10 files on empty table', async () => {
     await seedPredefinedWorkspaceFiles();
     const files = await listWorkspaceFiles();
-    expect(files).toHaveLength(9);
+    expect(files).toHaveLength(10);
   });
 
   it('seedPredefinedWorkspaceFiles is idempotent (no duplicates)', async () => {
     await seedPredefinedWorkspaceFiles();
     await seedPredefinedWorkspaceFiles();
     const files = await listWorkspaceFiles();
-    expect(files).toHaveLength(9);
+    expect(files).toHaveLength(10);
   });
 
   it('predefined files have correct names and owner=user', async () => {
@@ -142,6 +142,7 @@ describe('Predefined File Seeding', () => {
     const names = files.map(f => f.name).sort();
     expect(names).toEqual([
       'AGENTS.md',
+      'HEARTBEAT.md',
       'IDENTITY.md',
       'MEMORY.md',
       'SOUL.md',

--- a/packages/storage/lib/index.ts
+++ b/packages/storage/lib/index.ts
@@ -17,6 +17,8 @@ export {
   type DbScheduledTask,
   type DbTaskRunLog,
   type DbEmbeddingCache,
+  type DbHeartbeatState,
+  type DbHeartbeatLock,
 } from './impl/chat-db.js';
 export {
   createAgent,

--- a/pages/full-page-chat/src/FullPageChat.tsx
+++ b/pages/full-page-chat/src/FullPageChat.tsx
@@ -291,24 +291,44 @@ const FullPageChat = () => {
     const handler = (message: Record<string, unknown>) => {
       const type = message.type as string;
       const injectChatId = message.chatId as string;
-      if (!injectChatId || type !== 'CRON_CHAT_INJECT') return;
+      if (!injectChatId) return;
 
-      setChatId(prev => {
-        if (prev === injectChatId) {
-          reloadMessages(injectChatId);
-        } else {
-          const taskName = message.taskName as string | undefined;
-          toast.info(taskName ? t('toast_scheduledTask', taskName) : t('toast_scheduledTaskFired'), {
-            duration: 10000,
-          });
-        }
-        return prev;
-      });
+      if (type === 'CRON_CHAT_INJECT') {
+        setChatId(prev => {
+          if (prev === injectChatId) {
+            reloadMessages(injectChatId);
+          } else {
+            const taskName = message.taskName as string | undefined;
+            toast.info(taskName ? t('toast_scheduledTask', taskName) : t('toast_scheduledTaskFired'), {
+              duration: 10000,
+            });
+          }
+          return prev;
+        });
+        return;
+      }
+
+      if (type === 'HEARTBEAT_CHAT_DELIVERED') {
+        setChatId(prev => {
+          if (prev === injectChatId) {
+            reloadMessages(injectChatId);
+          } else {
+            toast.info(t('toast_heartbeatDelivered') ?? 'Heartbeat alert', {
+              action: {
+                label: t('toast_view'),
+                onClick: () => handleOpenSession(injectChatId),
+              },
+              duration: 10000,
+            });
+          }
+          return prev;
+        });
+      }
     };
 
     chrome.runtime.onMessage.addListener(handler);
     return () => chrome.runtime.onMessage.removeListener(handler);
-  }, [reloadMessages]);
+  }, [reloadMessages, handleOpenSession]);
 
   const stopSubagent = useCallback((runId: string) => {
     chrome.runtime.sendMessage({ type: 'SUBAGENT_STOP', runId }).catch(() => {});

--- a/pages/side-panel/src/SidePanel.tsx
+++ b/pages/side-panel/src/SidePanel.tsx
@@ -486,6 +486,25 @@ const SidePanel = () => {
         return;
       }
 
+      // Heartbeat delivered a non-ack response — show in chat UI
+      if (type === 'HEARTBEAT_CHAT_DELIVERED') {
+        setChatId(prev => {
+          if (prev === msgChatId) {
+            reloadMessages(msgChatId);
+          } else {
+            toast.info(t('toast_heartbeatDelivered') ?? 'Heartbeat alert', {
+              action: {
+                label: t('toast_view'),
+                onClick: () => loadAndSwitchToChat(msgChatId),
+              },
+              duration: 10000,
+            });
+          }
+          return prev;
+        });
+        return;
+      }
+
       if (!type?.startsWith('CHANNEL_STREAM_')) return;
 
       if (type === 'CHANNEL_STREAM_START') {


### PR DESCRIPTION
## Summary
- **Two-rule enablement resolver**: Default agent heartbeat runs automatically out of the box (implicit mode). When any agent has an explicit `heartbeat.<id>` config, semantics flip to opt-in mode.
- **Channel delivery**: Heartbeat output delivered directly to Telegram/WhatsApp channels from `run-once`, with best-effort error handling.
- **Chat UI notifications**: Toast in SidePanel when heartbeat produces a non-ack response, with "View" action to jump to the conversation.
- **Empty HEARTBEAT.md = skip**: Missing or placeholder file suppresses interval ticks to avoid burning tokens.
- **Dedup fix**: Suppress duplicate heartbeat sessions on rapid manual triggers (wake queue coalescing).

## Test plan
- [ ] Verify default agent heartbeat fires automatically on fresh install (no explicit config)
- [ ] Verify adding explicit `heartbeat.<agentId>` config switches to opt-in mode
- [ ] Verify heartbeat output delivered to active Telegram/WhatsApp channel
- [ ] Verify toast notification appears in SidePanel for heartbeat messages
- [ ] Run `pnpm test` — unit tests for config resolver, run-once, wake queue, sleep catch-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)