### PR TITLE
feat: add Requesty as an OpenAI-compatible provider

### DIFF
--- a/chrome-extension/src/background/agents/model-adapter.ts
+++ b/chrome-extension/src/background/agents/model-adapter.ts
@@ -34,6 +34,7 @@ const DEFAULT_BASE_URLS: Record<string, string> = {
   anthropic: 'https://api.anthropic.com',
   google: 'https://generativelanguage.googleapis.com',
   openrouter: 'https://openrouter.ai/api/v1',
+  requesty: 'https://router.requesty.ai/v1',
 };
 
 export const chatModelToPiModel = (config: ChatModel): ResolvedModel => {
@@ -62,6 +63,11 @@ export const chatModelToPiModel = (config: ChatModel): ResolvedModel => {
       api = 'openai-completions';
       baseUrl = DEFAULT_BASE_URLS.openrouter;
       provider = 'openrouter';
+      break;
+    case 'requesty':
+      api = 'openai-completions';
+      baseUrl = DEFAULT_BASE_URLS.requesty;
+      provider = 'requesty';
       break;
     case 'custom':
       api = 'openai-completions';

--- a/packages/config-panels/lib/model-config.tsx
+++ b/packages/config-panels/lib/model-config.tsx
@@ -62,6 +62,7 @@ const defaultModelIds: Record<string, string> = {
   anthropic: 'claude-sonnet-4-5',
   google: 'gemini-2.0-flash',
   openrouter: 'openai/gpt-4o',
+  requesty: 'openai/gpt-4o-mini',
   custom: '',
   azure: '',
   'openai-codex': 'gpt-5.3-codex',
@@ -96,6 +97,7 @@ const providers = [
   { value: 'anthropic', label: 'Anthropic' },
   { value: 'google', label: 'Google' },
   { value: 'openrouter', label: 'OpenRouter' },
+  { value: 'requesty', label: 'Requesty' },
   { value: 'azure', label: 'Azure OpenAI' },
   { value: 'openai-codex', label: 'OpenAI Codex (ChatGPT)' },
   { value: 'custom', label: 'OpenAI Compatible' },
@@ -266,7 +268,7 @@ const ModelConfig = () => {
           next.modelId = defaultModelIds[value] ?? '';
         }
         // Clear api when switching to non-OpenAI-compatible providers
-        if (!['openai', 'custom', 'openrouter', 'azure'].includes(value)) {
+        if (!['openai', 'custom', 'openrouter', 'requesty', 'azure'].includes(value)) {
           next.api = undefined;
         }
         // Azure provider: set Responses API as default
@@ -825,7 +827,7 @@ const ModelConfig = () => {
                     </div>
                   )}
 
-                  {['openai', 'custom', 'openrouter', 'azure'].includes(editForm.provider) && (
+                  {['openai', 'custom', 'openrouter', 'requesty', 'azure'].includes(editForm.provider) && (
                     <div className="grid gap-2">
                       <Label htmlFor="model-api">{t('model_apiFormat')}</Label>
                       <Select

--- a/packages/shared/lib/chat-types.ts
+++ b/packages/shared/lib/chat-types.ts
@@ -105,6 +105,7 @@ type ModelProvider =
   | 'anthropic'
   | 'google'
   | 'openrouter'
+  | 'requesty'
   | 'custom'
   | 'azure'
   | 'openai-codex'

--- a/packages/ui/lib/components/first-run-setup.tsx
+++ b/packages/ui/lib/components/first-run-setup.tsx
@@ -95,6 +95,12 @@ const providers = [
     defaultModel: 'openai/gpt-4o',
     defaultBase: 'https://openrouter.ai/api/v1',
   },
+  {
+    value: 'requesty',
+    label: 'Requesty',
+    defaultModel: 'openai/gpt-4o-mini',
+    defaultBase: 'https://router.requesty.ai/v1',
+  },
   { value: 'custom', label: 'OpenAI Compatible', defaultModel: '', defaultBase: '' },
 ];
 


### PR DESCRIPTION
## What

Adds Requesty as a named, OpenAI-compatible LLM provider, mirroring the existing OpenRouter wiring.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM gateway. It uses the same `provider/model` naming as OpenRouter (e.g. `openai/gpt-4o-mini`) and is reachable at `https://router.requesty.ai/v1`.

## Changes

- `chrome-extension/src/background/agents/model-adapter.ts` — add `requesty: 'https://router.requesty.ai/v1'` to `DEFAULT_BASE_URLS` and a `case 'requesty':` branch in the provider switch, mirroring the `openrouter` case.
- `packages/shared/lib/chat-types.ts` — add `requesty` to the provider type union.
- `packages/config-panels/lib/model-config.tsx` and `packages/ui/lib/components/first-run-setup.tsx` — add a Requesty entry to the provider picker, mirroring the OpenRouter entry.

## Testing

Tested live against the real endpoint: `POST https://router.requesty.ai/v1/chat/completions` with `openai/gpt-4o-mini` → HTTP 200 with a valid completion.

---

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust wording/placement or close it if it's not a fit.
